### PR TITLE
Fix for Linux App Service PM2 Startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "login.dfe.services",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
   "scripts": {
     "dev": "settings='./config/login.dfe.services.dev.json' node src/index.js",
     "test": "./node_modules/.bin/jest"


### PR DESCRIPTION
Removed main so PM2 picks-up process.json on Linux App Services