### PR TITLE
Adds mapper to org_ fields expected by the codebase

### DIFF
--- a/src/infrastructure/organisations/api.js
+++ b/src/infrastructure/organisations/api.js
@@ -107,7 +107,8 @@ const getRequestsForOrganisation = async (organisationId, correlationId) => {
 };
 
 const getRequestById = async (...args) => {
-  return await organisation.getUserOrganisationRequest(...args);
+  const { dataValues, ...request } = await organisation.getUserOrganisationRequest(...args);
+  return { ...dataValues, ...request, org_id: dataValues.organisation_id, org_name: dataValues.Organisation.name };
 };
 
 const updateRequestById = async (requestId, status, actionedBy, actionedReason, actionedAt, correlationId) => {


### PR DESCRIPTION
Existing code was expecting org_name and org_id ... I'm unsure where this mapping was previously happening as they are not fields in the database O_o