### PR TITLE
PR-feature-NSA-5096-name text can overlap with links

### DIFF
--- a/src/app/users/views/services.ejs
+++ b/src/app/users/views/services.ejs
@@ -11,7 +11,7 @@
     <% } %>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-xl">
+            <h1 class="govuk-heading-xl text-break">
                 <span class="govuk-caption-xl"><%= locals.user.email %></span>
                 <%= locals.user.firstName%> <%= locals.user.lastName%>
             </h1>


### PR DESCRIPTION
New CSS class has been applied to the name header. The css class added in to ui.toolkit