### PR TITLE
[NSA-7022] - Hot fix - sub-service requests 

### DIFF
--- a/src/app/requestService/approveRolesRequest.js
+++ b/src/app/requestService/approveRolesRequest.js
@@ -103,7 +103,7 @@ const get = async (req, res) => {
     req.session.user.firstName = endUser.firstName;
     req.session.user.lastName = endUser.lastName;
     req.session.user.email = endUser.email;
-    req.session.user.services = [viewModel.service];
+    req.session.user.services = [{ serviceId, roles }];
     req.session.user.serviceId = viewModel.service.serviceId;
     req.session.user.roleIds = roles;
     req.session.action = action;
@@ -176,8 +176,8 @@ const post = async (req, res) => {
   }
 
   logger.audit({
-    type: 'services',
-    subType: 'sub-service-request',
+    type: 'sub-service',
+    subType: 'sub-service request Approved',
     userId: approverDetails.sub,
     userEmail: approverDetails.email,
     application: config.loggerSettings.applicationName,

--- a/src/app/requestService/confirmEditRolesRequest.js
+++ b/src/app/requestService/confirmEditRolesRequest.js
@@ -111,8 +111,8 @@ const post = async (req, res) => {
   );
 
   logger.audit({
-    type: 'services',
-    subType: 'sub-services-request',
+    type: 'sub-service',
+    subType: 'sub-service request',
     userId: uid,
     userEmail: req.user.email,
     application: config.loggerSettings.applicationName,

--- a/src/app/requestService/rejectRolesRequest.js
+++ b/src/app/requestService/rejectRolesRequest.js
@@ -154,8 +154,8 @@ const post = async (req, res) => {
     );
   }
   logger.audit({
-    type: 'services',
-    subType: 'sub-service-request',
+    type: 'sub-service',
+    subType: 'sub-service request Rejected',
     userId: approverDetails.sub,
     userEmail: approverDetails.email,
     application: config.loggerSettings.applicationName,
@@ -173,7 +173,7 @@ const post = async (req, res) => {
   res.flash('heading', 'Sub-service request rejected');
   res.flash(
     'message',
-    'The user who raised the request will receive an email to tell them their sub-service access request has been rejected',
+    'The user who raised the request will receive an email to tell them their sub-service access request has been rejected.',
   );
 
   res.redirect('/my-services');

--- a/src/app/requestService/requestEditRoles.js
+++ b/src/app/requestService/requestEditRoles.js
@@ -56,7 +56,13 @@ const get = async (req, res) => {
   }
 
   const model = await getViewModel(req);
-  model.service.roles = model.userService.roles;
+  if (req.session?.service?.roles) {
+    const sessionRoles = req.session.service.roles;
+    model.service.roles = sessionRoles.map((x) => ({ id: x }));
+  } else {
+    model.service.roles = model.userService.roles;
+  }
+
   saveRoleInSession(req, model.service.roles);
   renderRequestEditRoles(res, model);
 };

--- a/src/app/users/selectServiceWithOrganisation.js
+++ b/src/app/users/selectServiceWithOrganisation.js
@@ -93,6 +93,9 @@ const post = async (req, res) => {
   const serviceOrgDetails = serviceOrganisations.find((serviceOrg) => {
     return serviceOrg.id === req.body.selectedServiceOrganisation;
   });
+  if (req.session?.service?.roles) {
+    req.session.service.roles = undefined;
+  }
 
   return res.redirect(buildRedirectURL(req, serviceOrgDetails));
 };

--- a/test/unit/app/requestService/approveRolesRequest.post.test.js
+++ b/test/unit/app/requestService/approveRolesRequest.post.test.js
@@ -253,8 +253,8 @@ describe('When approving a sub service request', () => {
       'approver.one@unit.test (approverId: approver1) approved sub-service request for (serviceId: service1) and sub-services (roleIds: ["role1"]) and organisation (orgId: organisationId) for end user (endUserId: endUser1) - requestId (reqId: sub-service-req-ID)',
     );
     expect(logger.audit.mock.calls[0][0]).toMatchObject({
-      type: 'services',
-      subType: 'sub-service-request',
+      type: 'sub-service',
+      subType: 'sub-service request Approved',
       userId: 'approver1',
       userEmail: 'approver.one@unit.test',
     });

--- a/test/unit/app/requestService/confirmEditRolesRequest.post.test.js
+++ b/test/unit/app/requestService/confirmEditRolesRequest.post.test.js
@@ -178,8 +178,8 @@ describe('When confirming and submiting a sub-service request', () => {
     expect(logger.audit.mock.calls).toHaveLength(1);
     expect(logger.audit.mock.calls[0][0].message).toBe(loggerAuditMessage);
     expect(logger.audit.mock.calls[0][0]).toMatchObject({
-      type: 'services',
-      subType: 'sub-services-request',
+      type: 'sub-service',
+      subType: 'sub-service request',
       userId: 'user1',
       userEmail: 'user.one@unit.test',
       env: 'test-run',

--- a/test/unit/app/requestService/rejectRolesRequest.post.test.js
+++ b/test/unit/app/requestService/rejectRolesRequest.post.test.js
@@ -258,8 +258,8 @@ describe('When approving a sub service request', () => {
       'approver.one@unit.test (approverId: approver1) rejected sub-service request for (serviceId: service1) and sub-services (roleIds: ["role1"]) for organisation (orgId: organisationId) for end user (endUserId: endUser1).  - requestId (reqId: sub-service-req-ID)',
     );
     expect(logger.audit.mock.calls[0][0]).toMatchObject({
-      type: 'services',
-      subType: 'sub-service-request',
+      type: 'sub-service',
+      subType: 'sub-service request Rejected',
       userId: 'approver1',
       userEmail: 'approver.one@unit.test',
     });
@@ -275,7 +275,7 @@ describe('When approving a sub service request', () => {
     expect(res.flash.mock.calls[1][1]).toBe('Sub-service request rejected');
     expect(res.flash.mock.calls[2][0]).toBe('message');
     expect(res.flash.mock.calls[2][1]).toBe(
-      'The user who raised the request will receive an email to tell them their sub-service access request has been rejected',
+      'The user who raised the request will receive an email to tell them their sub-service access request has been rejected.',
     );
   });
 


### PR DESCRIPTION
Fixed the following issues:

1. Add a  full stop at the end of Sub-service request rejected banner to keep it consistent with rest of the banners 

2. Display user friendly message on Audit logs when the sub service is approved or rejected. It is showing as services/sub-service-request in audit log which is not clear.

3. End user journey - The selected sub-services are not retained when the end user clicks ‘back ' link from 'Review request’ page

4. Approver amends the request journey - When an approver review the request and decides to Amend the sub-services , empty role page is displayed without the end-user selected roles.
