### PR TITLE
[NSA-7147] - Updated sub-service request success banner wording

### DIFF
--- a/src/app/requestService/confirmEditRolesRequest.js
+++ b/src/app/requestService/confirmEditRolesRequest.js
@@ -124,11 +124,11 @@ const post = async (req, res) => {
     )}) for organisation (orgId: ${organisationDetails.organisation.id}) - requestId (reqId: ${subServiceReqId})`,
   });
 
-  res.flash('title', `Success`);
-  res.flash('heading', `Sub-service requested: ${service.name}`);
+  res.flash('title', 'Success');
+  res.flash('heading', 'Sub-service changes requested');
   res.flash(
     'message',
-    `Your request has been sent to all approvers at <b>${orgName}</b>. Requests should be approved or rejected within 5 days of being raised.`,
+    `Your request to change sub-service access has been sent to all approvers at ${orgName}.<br>Your request will be approved or rejected within 5 days.`,
   );
 
   return res.redirect('/my-services');

--- a/test/unit/app/requestService/confirmEditRolesRequest.post.test.js
+++ b/test/unit/app/requestService/confirmEditRolesRequest.post.test.js
@@ -193,10 +193,10 @@ describe('When confirming and submiting a sub-service request', () => {
     expect(res.flash.mock.calls[0][0]).toBe('title');
     expect(res.flash.mock.calls[0][1]).toBe('Success');
     expect(res.flash.mock.calls[1][0]).toBe('heading');
-    expect(res.flash.mock.calls[1][1]).toBe('Sub-service requested: service name');
+    expect(res.flash.mock.calls[1][1]).toBe('Sub-service changes requested');
     expect(res.flash.mock.calls[2][0]).toBe('message');
     expect(res.flash.mock.calls[2][1]).toBe(
-      'Your request has been sent to all approvers at <b>organisationName</b>. Requests should be approved or rejected within 5 days of being raised.',
+      'Your request to change sub-service access has been sent to all approvers at organisationName.<br>Your request will be approved or rejected within 5 days.',
     );
   });
 


### PR DESCRIPTION
Ticket: https://dfe-secureaccess.atlassian.net/browse/NSA-7147
Changes: 

- wording changes for the success banner displayed when a user successfully creates a sub-service requests