### PR TITLE
NSA-7109] Add permission level to sub-service approved email

### DIFF
--- a/src/app/accessRequests/reviewSubServiceRequest.js
+++ b/src/app/accessRequests/reviewSubServiceRequest.js
@@ -6,6 +6,7 @@ const {
   getAndMapServiceRequest,
   generateFlashMessages,
   getRoleAndServiceNames,
+  getOrganisationPermissionLevel,
 } = require('./utils');
 const { createSubServiceAddedBanners } = require('../home/userBannersHandlers');
 const { isServiceEmailNotificationAllowed } = require('../../../src/infrastructure/applications');
@@ -147,6 +148,12 @@ const post = async (req, res) => {
           connectionString: config.notifications.connectionString,
         });
 
+        const permissionLevel = await getOrganisationPermissionLevel(
+          model.viewModel.user_id,
+          model.viewModel.org_id,
+          req.params.rid,
+        );
+
         await notificationClient.sendSubServiceRequestApproved(
           model.viewModel.endUsersEmail,
           model.viewModel.endUsersGivenName,
@@ -154,6 +161,7 @@ const post = async (req, res) => {
           model.viewModel.org_name,
           serviceName,
           rolesName,
+          permissionLevel,
         );
       }
 

--- a/src/app/requestService/approveRolesRequest.js
+++ b/src/app/requestService/approveRolesRequest.js
@@ -7,6 +7,8 @@ const { getUserServiceRequestStatus, updateServiceRequest } = require('./utils')
 const { isServiceEmailNotificationAllowed } = require('../../../src/infrastructure/applications');
 const { createSubServiceAddedBanners } = require('../home/userBannersHandlers');
 
+const { getOrganisationPermissionLevel } = require('../../app/accessRequests/utils');
+
 const logger = require('../../infrastructure/logger');
 const config = require('../../infrastructure/config');
 
@@ -167,6 +169,7 @@ const post = async (req, res) => {
   await createSubServiceAddedBanners(endUserId, service.name, rolesName);
 
   if (isEmailAllowed) {
+    const permissionLevel = await getOrganisationPermissionLevel(endUserId, orgId, reqId);
     const notificationClient = new NotificationClient({ connectionString: config.notifications.connectionString });
     await notificationClient.sendSubServiceRequestApproved(
       endUserDetails.email,
@@ -175,6 +178,7 @@ const post = async (req, res) => {
       organisation.name,
       service.name,
       rolesName,
+      permissionLevel,
     );
   }
 


### PR DESCRIPTION
**Jira ticket:** https://dfe-secureaccess.atlassian.net/browse/NSA-7109
**Changes:** 

- added functionality to include the organisation permission level into the confirmation email for sub-service requests approved for both journeys (email / Approver's dashboard)
- updated the unit tests to cover this new functionality 
- improved unit testing coverage for sub-service approval journeys