### PR TITLE
[DSI-6825] Remove logging of unnecessary information

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.0.0",
         "login.dfe.notifications.client": "github:DFE-Digital/login.dfe.notifications.client#v5.2.0",
         "login.dfe.policy-engine": "git+https://github.com/DFE-Digital/login.dfe.policy-engine.git#v3.0.9",
-        "login.dfe.request-promise-retry": "git+https://github.com/DFE-Digital/login.dfe.request-promise-retry.git#v3.1.0",
+        "login.dfe.request-promise-retry": "github:DFE-Digital/login.dfe.request-promise-retry#v3.1.0",
         "login.dfe.sanitization": "git+https://github.com/DFE-Digital/login.dfe.sanitization.git#v3.0.0",
         "login.dfe.validation": "github:DFE-Digital/login.dfe.validation.git#v2.0.3",
         "login.dfe.winston-appinsights": "git+https://github.com/DFE-Digital/login.dfe.winston-appinsights.git#v5.0.0",
@@ -10102,8 +10102,8 @@
       }
     },
     "node_modules/login.dfe.request-promise-retry": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.request-promise-retry.git#cedf7a91a4c7e1d51f51389c4ff3c2aa4273aa1d",
+      "version": "3.1.0",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.request-promise-retry.git#c6cb2494c9dce08cc41bdcbe3d999059c3a13237",
       "license": "MIT",
       "dependencies": {
         "login.dfe.async-retry": "git+https://github.com/DFE-Digital/login.dfe.async-retry.git#v2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.0.0",
         "login.dfe.notifications.client": "github:DFE-Digital/login.dfe.notifications.client#v5.2.0",
         "login.dfe.policy-engine": "git+https://github.com/DFE-Digital/login.dfe.policy-engine.git#v3.0.9",
-        "login.dfe.request-promise-retry": "git+https://github.com/DFE-Digital/login.dfe.request-promise-retry.git#v3.0.0",
+        "login.dfe.request-promise-retry": "git+https://github.com/DFE-Digital/login.dfe.request-promise-retry.git#v3.1.0",
         "login.dfe.sanitization": "git+https://github.com/DFE-Digital/login.dfe.sanitization.git#v3.0.0",
         "login.dfe.validation": "github:DFE-Digital/login.dfe.validation.git#v2.0.3",
         "login.dfe.winston-appinsights": "git+https://github.com/DFE-Digital/login.dfe.winston-appinsights.git#v5.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.0.0",
     "login.dfe.notifications.client": "github:DFE-Digital/login.dfe.notifications.client#v5.2.0",
     "login.dfe.policy-engine": "git+https://github.com/DFE-Digital/login.dfe.policy-engine.git#v3.0.9",
-    "login.dfe.request-promise-retry": "git+https://github.com/DFE-Digital/login.dfe.request-promise-retry.git#v3.0.0",
+    "login.dfe.request-promise-retry": "git+https://github.com/DFE-Digital/login.dfe.request-promise-retry.git#v3.1.0",
     "login.dfe.sanitization": "git+https://github.com/DFE-Digital/login.dfe.sanitization.git#v3.0.0",
     "login.dfe.validation": "github:DFE-Digital/login.dfe.validation.git#v2.0.3",
     "login.dfe.winston-appinsights": "git+https://github.com/DFE-Digital/login.dfe.winston-appinsights.git#v5.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "login.dfe.jwt-strategies": "github:DFE-Digital/login.dfe.jwt-strategies#v4.0.0",
     "login.dfe.notifications.client": "github:DFE-Digital/login.dfe.notifications.client#v5.2.0",
     "login.dfe.policy-engine": "git+https://github.com/DFE-Digital/login.dfe.policy-engine.git#v3.0.9",
-    "login.dfe.request-promise-retry": "git+https://github.com/DFE-Digital/login.dfe.request-promise-retry.git#v3.1.0",
+    "login.dfe.request-promise-retry": "github:DFE-Digital/login.dfe.request-promise-retry#v3.1.0",
     "login.dfe.sanitization": "git+https://github.com/DFE-Digital/login.dfe.sanitization.git#v3.0.0",
     "login.dfe.validation": "github:DFE-Digital/login.dfe.validation.git#v2.0.3",
     "login.dfe.winston-appinsights": "git+https://github.com/DFE-Digital/login.dfe.winston-appinsights.git#v5.0.0",


### PR DESCRIPTION
**Parent Ticket**: https://dfe-secureaccess.atlassian.net/browse/DSI-6725
**Ticket**: https://dfe-secureaccess.atlassian.net/browse/DSI-6825

Changes:

Updated `login.dfe.request-promise-retry` package version to not log every request body.
Updated `logger` to only send audit records containing the email address to the `Audit DB`, and not to the `console/app insights`.