### PR TITLE
[DSI-7010] ITHC changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.2",
         "login.dfe.audit.transporter": "^4.0.1",
         "login.dfe.config.schema.common": "github:DFE-Digital/login.dfe.config.schema.common#v2.1.4",
-        "login.dfe.dao": "^4.2.13",
+        "login.dfe.dao": "^4.2.15",
         "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",
         "login.dfe.express-flash-2": "github:DFE-Digital/login.dfe.express-flash-2#v2.0.1",
         "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.1",
@@ -46,7 +46,7 @@
         "prettier": "^3.0.3",
         "redis": "^4.6.12",
         "simpl-schema": "^3.4.1",
-        "tedious": "^16.5.0",
+        "tedious": "^18.2.1",
         "winston": "^3.3.3"
       },
       "devDependencies": {
@@ -134,9 +134,9 @@
       }
     },
     "node_modules/@azure/core-client": {
-      "version": "1.9.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-client/-/core-client-1.9.1.tgz",
-      "integrity": "sha1-t/w80ke6oeP+4fIVAkprborvWDo=",
+      "version": "1.9.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-client/-/core-client-1.9.2.tgz",
+      "integrity": "sha1-b8ac7igWiDq2xc3WU+5PL/l3T3Q=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
@@ -289,20 +289,20 @@
       }
     },
     "node_modules/@azure/identity": {
-      "version": "3.4.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/identity/-/identity-3.4.2.tgz",
-      "integrity": "sha1-awFyTJyqx8ratrY8dlhDRb2o4t4=",
+      "version": "4.3.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/identity/-/identity-4.3.0.tgz",
+      "integrity": "sha1-6NprO/HfTeFRHoE6cWaktbSpnKE=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
         "@azure/core-auth": "^1.5.0",
-        "@azure/core-client": "^1.4.0",
+        "@azure/core-client": "^1.9.2",
         "@azure/core-rest-pipeline": "^1.1.0",
         "@azure/core-tracing": "^1.0.0",
-        "@azure/core-util": "^1.6.1",
+        "@azure/core-util": "^1.3.0",
         "@azure/logger": "^1.0.0",
-        "@azure/msal-browser": "^3.5.0",
-        "@azure/msal-node": "^2.5.1",
+        "@azure/msal-browser": "^3.11.1",
+        "@azure/msal-node": "^2.9.2",
         "events": "^3.0.0",
         "jws": "^4.0.0",
         "open": "^8.0.0",
@@ -310,7 +310,7 @@
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/identity/node_modules/@azure/abort-controller": {
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/@azure/identity/node_modules/@azure/core-util": {
-      "version": "1.8.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-util/-/core-util-1.8.1.tgz",
-      "integrity": "sha1-ShTdszjcGs8up2KLWxzM21tvv78=",
+      "version": "1.9.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/core-util/-/core-util-1.9.0.tgz",
+      "integrity": "sha1-Rpr9fmRS1TiLGJ+Q0z93VrCyENE=",
       "license": "MIT",
       "dependencies": {
         "@azure/abort-controller": "^2.0.0",
@@ -339,9 +339,9 @@
       }
     },
     "node_modules/@azure/identity/node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
-      "version": "2.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-2.1.1.tgz",
-      "integrity": "sha1-rUqWTOUKHq7XDtLS73fI3lcI0Qs=",
+      "version": "2.1.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha1-Qv4MyrI4QdmQWBLFjxCC0neEVm0=",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -418,21 +418,21 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "3.11.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-browser/-/msal-browser-3.11.1.tgz",
-      "integrity": "sha1-JRFccGhTTr6FzjZlP5dxtu9aLkY=",
+      "version": "3.17.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-browser/-/msal-browser-3.17.0.tgz",
+      "integrity": "sha1-3unMrlhiOefgcIsmH3/6W8fgD7c=",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "14.8.1"
+        "@azure/msal-common": "14.12.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "14.8.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-14.8.1.tgz",
-      "integrity": "sha1-oOvhKiPxn29ITe04rNUlR08Fb/Y=",
+      "version": "14.12.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-14.12.0.tgz",
+      "integrity": "sha1-hEq+JpsHH4+olJ2twqe2W7sUdYg=",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
@@ -449,14 +449,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-      "version": "14.12.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-14.12.0.tgz",
-      "integrity": "sha1-hEq+JpsHH4+olJ2twqe2W7sUdYg=",
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/opentelemetry-instrumentation-azure-sdk": {
@@ -2816,6 +2808,7 @@
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/array-buffer-byte-length/-/array-buffer-byte-length-1.0.1.tgz",
       "integrity": "sha1-HlWD7BZ2NUCieuUu7Zn/iZIjVo8=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.5",
@@ -2918,6 +2911,7 @@
       "version": "1.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.3.tgz",
       "integrity": "sha1-CXly9CVeQbw0JeN9w/ZCHPmu/eY=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -4055,6 +4049,7 @@
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
       "integrity": "sha1-jqYybv7Bei5CYgaW5nHX1ai8ZrI=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.6",
@@ -4072,6 +4067,7 @@
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/data-view-byte-length/-/data-view-byte-length-1.0.1.tgz",
       "integrity": "sha1-kHIcqV/ygGd+t5N0n84QETR2aeI=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -4089,6 +4085,7 @@
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/data-view-byte-offset/-/data-view-byte-offset-1.0.0.tgz",
       "integrity": "sha1-Xgu/tIKO0tG5tADNin0Rm8oP8Yo=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.6",
@@ -4189,6 +4186,7 @@
       "version": "1.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha1-EHgcxhbrlRqAoDS6/Kpzd/avK2w=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -4413,6 +4411,7 @@
       "version": "1.23.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-abstract/-/es-abstract-1.23.3.tgz",
       "integrity": "sha1-jwxaNc0hUxJXPFonyH39bIgaCqA=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -4469,28 +4468,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es-aggregate-error": {
-      "version": "1.0.13",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-aggregate-error/-/es-aggregate-error-1.0.13.tgz",
-      "integrity": "sha1-fyi3fJ2NCbvNOkZuS+n+AvqYUgE=",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "globalthis": "^1.0.3",
-        "has-property-descriptors": "^1.0.2",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/es-define-property": {
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-define-property/-/es-define-property-1.0.0.tgz",
@@ -4516,6 +4493,7 @@
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
       "integrity": "sha1-3bVc1HrC4kBwEmC8Ko4x7LZD2UE=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -4528,6 +4506,7 @@
       "version": "2.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz",
       "integrity": "sha1-i7YPCkQMLkKBliQoQ41YVFrzl3c=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.4",
@@ -4552,6 +4531,7 @@
       "version": "1.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.4",
@@ -5566,6 +5546,7 @@
       "version": "1.1.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
       "integrity": "sha1-zfMVt9kO53pMbuIWw8M2LaB1M/0=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -5584,6 +5565,7 @@
       "version": "1.2.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha1-BAT+TuK6L2B/Dg7DyAuumUEzuDQ=",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5663,6 +5645,7 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-symbol-description/-/get-symbol-description-1.0.2.tgz",
       "integrity": "sha1-UzdE1aogrKTgecjl2vf9RCAoIfU=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.5",
@@ -5721,6 +5704,7 @@
       "version": "1.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globalthis/-/globalthis-1.0.3.tgz",
       "integrity": "sha1-WFKIKlK4DcMBsGYCc+HtCC8LbM8=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.1.3"
@@ -5761,6 +5745,7 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-bigints/-/has-bigints-1.0.2.tgz",
       "integrity": "sha1-CHG9Pj1RYm9soJZmaLo11WAtbqo=",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6068,6 +6053,7 @@
       "version": "1.0.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/internal-slot/-/internal-slot-1.0.7.tgz",
       "integrity": "sha1-wG3Mo+2HQkmIEAewpVI7FyoZCAI=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -6131,6 +6117,7 @@
       "version": "3.0.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-array-buffer/-/is-array-buffer-3.0.4.tgz",
       "integrity": "sha1-eh+Ss9Ye3SvGXSTxMFMOqT1/rpg=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -6154,6 +6141,7 @@
       "version": "1.0.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha1-CBR6GHW8KzIAXUHM2Ckd/8ZpHfM=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.1"
@@ -6166,6 +6154,7 @@
       "version": "1.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
       "integrity": "sha1-XG3CACRt2TIa5LiFoRS7H3X2Nxk=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -6229,6 +6218,7 @@
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-data-view/-/is-data-view-1.0.1.tgz",
       "integrity": "sha1-S006URtw89wm1CwDypylFdhHdZ8=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-typed-array": "^1.1.13"
@@ -6244,6 +6234,7 @@
       "version": "1.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha1-CEHVU25yTCVZe/bqYuG9OCmN8x8=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -6351,6 +6342,7 @@
       "version": "2.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
       "integrity": "sha1-ztkDoCespjgbd3pXQwadc3akl0c=",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6372,6 +6364,7 @@
       "version": "1.0.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-number-object/-/is-number-object-1.0.7.tgz",
       "integrity": "sha1-WdUK2kxFJReE6ZBPUkbHQvB6Qvw=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -6418,6 +6411,7 @@
       "version": "1.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-shared-array-buffer/-/is-shared-array-buffer-1.0.3.tgz",
       "integrity": "sha1-Ejfxy6BZzbYkMdN43MN9loAYFog=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7"
@@ -6445,6 +6439,7 @@
       "version": "1.0.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-string/-/is-string-1.0.7.tgz",
       "integrity": "sha1-DdEr8gBvJVu1j2lREO/3SR7rwP0=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
@@ -6460,6 +6455,7 @@
       "version": "1.0.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-symbol/-/is-symbol-1.0.4.tgz",
       "integrity": "sha1-ptrJO2NbBjymhyI23oiRClevE5w=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.2"
@@ -6490,6 +6486,7 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha1-lSnzg6kzggXol2XgOS78LxAPBvI=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2"
@@ -6514,6 +6511,7 @@
       "version": "2.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM=",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -8449,12 +8447,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbi": {
-      "version": "4.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsbi/-/jsbi-4.3.0.tgz",
-      "integrity": "sha1-tU7gdPtvy8AGGVWTBcj36RKwR0E=",
-      "license": "Apache-2.0"
-    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsesc/-/jsesc-2.5.2.tgz",
@@ -8749,9 +8741,9 @@
       }
     },
     "node_modules/login.dfe.dao": {
-      "version": "4.2.13",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.dao/-/login.dfe.dao-4.2.13.tgz",
-      "integrity": "sha1-Qjo9k3GIMFdFWwv4UzWy2fxVfC8=",
+      "version": "4.2.15",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.dao/-/login.dfe.dao-4.2.15.tgz",
+      "integrity": "sha1-iLZcqaitaFu3zagKLORogxYb50M=",
       "license": "ISC",
       "dependencies": {
         "eslint": "^8.12.0",
@@ -8763,7 +8755,7 @@
         "sequelize": "^6.17.0",
         "sequelize-mock": "^0.10.2",
         "simpl-schema": "^3.4.1",
-        "tedious": "^16.4.0",
+        "tedious": "^18.2.1",
         "uuid": "^9.0.0",
         "verror": "^1.10.1"
       }
@@ -9221,12 +9213,6 @@
         "node": "*"
       }
     },
-    "node_modules/node-abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha1-qUN36WSpo3rDl22EjLXHZYM7hUg=",
-      "license": "MIT"
-    },
     "node_modules/node-cache": {
       "version": "5.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/node-cache/-/node-cache-5.1.2.tgz",
@@ -9357,6 +9343,7 @@
       "version": "1.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9366,6 +9353,7 @@
       "version": "4.1.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object.assign/-/object.assign-4.1.5.tgz",
       "integrity": "sha1-OoM/mrf9uA/J6NIwDIA9IW2P27A=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.5",
@@ -10359,6 +10347,7 @@
       "version": "1.5.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
       "integrity": "sha1-E49kSjNQ+YGoWMRPa7GmH/Wb4zQ=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.6",
@@ -10563,6 +10552,7 @@
       "version": "1.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
       "integrity": "sha1-gdd+4MTouGNjUifHISeN1STCDts=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -10601,6 +10591,7 @@
       "version": "1.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
       "integrity": "sha1-pbTA8G4KtQ6iw5XBTYNxIykkw3c=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.6",
@@ -10816,6 +10807,7 @@
       "version": "2.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/set-function-name/-/set-function-name-2.0.2.tgz",
       "integrity": "sha1-FqcFxaDcL15jjKltiozU4cK5CYU=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -11079,6 +11071,7 @@
       "version": "1.2.9",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz",
       "integrity": "sha1-tvoybXLSx4tt8C93Wcc/j2J0+qQ=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -11097,6 +11090,7 @@
       "version": "1.0.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trimend/-/string.prototype.trimend-1.0.8.tgz",
       "integrity": "sha1-NlG4UTcZ6Kn0jefy93ZAsmZSsik=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -11111,6 +11105,7 @@
       "version": "1.0.8",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
       "integrity": "sha1-fug03ajHwX7/MRhHK7Nb/tqjTd4=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -11334,25 +11329,23 @@
       }
     },
     "node_modules/tedious": {
-      "version": "16.7.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-16.7.1.tgz",
-      "integrity": "sha1-EZDzD9maQT8dySUN7kg1zweItlA=",
+      "version": "18.2.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tedious/-/tedious-18.2.1.tgz",
+      "integrity": "sha1-s4IYi6e1yAo7Empch26C9P9efwk=",
       "license": "MIT",
       "dependencies": {
-        "@azure/identity": "^3.4.1",
+        "@azure/identity": "^4.2.1",
         "@azure/keyvault-keys": "^4.4.0",
-        "@js-joda/core": "^5.5.3",
-        "bl": "^6.0.3",
-        "es-aggregate-error": "^1.0.9",
+        "@js-joda/core": "^5.6.1",
+        "@types/node": ">=18",
+        "bl": "^6.0.11",
         "iconv-lite": "^0.6.3",
         "js-md4": "^0.3.2",
-        "jsbi": "^4.3.0",
         "native-duplexpair": "^1.0.0",
-        "node-abort-controller": "^3.1.1",
-        "sprintf-js": "^1.1.2"
+        "sprintf-js": "^1.1.3"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/tedious/node_modules/iconv-lite": {
@@ -11555,6 +11548,7 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
       "integrity": "sha1-GGfF2Dsg/LXM8yZJ5eL8dCRHT/M=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -11569,6 +11563,7 @@
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-byte-length/-/typed-array-byte-length-1.0.1.tgz",
       "integrity": "sha1-2Sly08/5mj+i52Wij83A8did7Gc=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -11588,6 +11583,7 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-byte-offset/-/typed-array-byte-offset-1.0.2.tgz",
       "integrity": "sha1-+eway5JZ85UJPkVn6zwopYDQIGM=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -11608,6 +11604,7 @@
       "version": "1.0.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/typed-array-length/-/typed-array-length-1.0.6.tgz",
       "integrity": "sha1-VxVSB8duZKNFdILf3BydHTxMc6M=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -11640,6 +11637,7 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
       "integrity": "sha1-KQMgIQV9Xmzb0IxRKcIm3/jtb54=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -11833,6 +11831,7 @@
       "version": "1.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha1-E3V7yJsgmwSf5dhkMOIc9AqJqOY=",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.2",
     "login.dfe.audit.transporter": "^4.0.1",
     "login.dfe.config.schema.common": "github:DFE-Digital/login.dfe.config.schema.common#v2.1.4",
-    "login.dfe.dao": "^4.2.13",
+    "login.dfe.dao": "^4.2.15",
     "login.dfe.express-error-handling": "github:DFE-Digital/login.dfe.express-error-handling#v3.0.1",
     "login.dfe.express-flash-2": "github:DFE-Digital/login.dfe.express-flash-2#v2.0.1",
     "login.dfe.healthcheck": "github:DFE-Digital/login.dfe.healthcheck#v3.0.1",
@@ -59,7 +59,7 @@
     "prettier": "^3.0.3",
     "redis": "^4.6.12",
     "simpl-schema": "^3.4.1",
-    "tedious": "^16.5.0",
+    "tedious": "^18.2.1",
     "winston": "^3.3.3"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -62,35 +62,41 @@ const init = async () => {
 
   if (config.hostingEnvironment.hstsMaxAge) {
     app.use(helmet({
-      noCache: true,
-      frameguard: {
-        action: 'deny',
-      },
-      hsts: {
+      strictTransportSecurity: {
         maxAge: config.hostingEnvironment.hstsMaxAge,
         preload: true,
-      },
+        includeSubDomains: true,
+      }
     }));
   }
 
   logger.info('set helmet policy defaults');
 
   // Setting helmet Content Security Policy
-  const scriptSources = ["'self'", "'unsafe-inline'", "'unsafe-eval'", 'localhost', '*.signin.education.gov.uk'];
+  const self = "'self'";
+  const allowedOrigin = '*.signin.education.gov.uk';
+
+  const scriptSources = [self, "'unsafe-inline'", "'unsafe-eval'", allowedOrigin];
+  const styleSources = [self, "'unsafe-inline'", allowedOrigin];
+  const imgSources = [self, 'data:', 'blob:', allowedOrigin];
+  const fontSources = [self, 'data:', allowedOrigin];
+
+  if (config.hostingEnvironment.env === 'dev') {
+    scriptSources.push('localhost');
+    styleSources.push('localhost');
+    imgSources.push('localhost');
+    fontSources.push('localhost');
+  }
 
   app.use(helmet.contentSecurityPolicy({
-    browserSniff: false,
-    setAllHeaders: false,
     directives: {
-      defaultSrc: ["'self'"],
-      childSrc: ["'none'"],
-      objectSrc: ["'none'"],
+      defaultSrc: [self],
       scriptSrc: scriptSources,
-      styleSrc: ["'self'", "'unsafe-inline'", 'localhost', '*.signin.education.gov.uk'],
-      imgSrc: ["'self'", 'data:', 'blob:', 'localhost', '*.signin.education.gov.uk'],
-      fontSrc: ["'self'", 'data:', '*.signin.education.gov.uk'],
-      connectSrc: ["'self'"],
-      formAction: ["'self'", '*'],
+      styleSrc: styleSources,
+      imgSrc: imgSources,
+      fontSrc: fontSources,
+      connectSrc: [self],
+      formAction: [self, '*'],
     },
   }));
 


### PR DESCRIPTION
## Summary
**Jira ticket:** https://dfe-secureaccess.atlassian.net/browse/DSI-7010
**Progress:** https://dfe-secureaccess.atlassian.net.mcas.ms/wiki/spaces/NSA/pages/3947528194/ITHC+April+2024+-+Medium+Priority+Recommendations
## Changes
- Content security policy has been refactored to exclude localhost for live environments:
      - Add the Header X-Contact-Type-Options
      - Set the Strict-Transport-Security where headers missing
      - Remove CSP headers extra information
      - Set X-Frame-Options
      - Set X-XSS-Protection
      - Set X-Content-Type-Options
      - Remove fingerprints of server e.g. powered by express
- Upgraded package versions fix 3 moderate severity vulnerabilities: 
      - `login.dfe.dao` to `^4.2.15`
      -  `tedious` to `^18.2.1` 
