### PR TITLE
[DSI-7053] Show and hide approvers in organisations table

### DIFF
--- a/src/app/organisations/views/organisations.ejs
+++ b/src/app/organisations/views/organisations.ejs
@@ -151,29 +151,29 @@
                                     <% if (organisation.approvers && organisation.approvers.length === 0) { %>
                                         No approvers
                                     <% } else if (organisation.approvers) { %>
-                                        <a class="govuk-link-bold govuk-link--no-visited-state toggle-open" href="">
-                                            Show approvers
-                                            <span class="govuk-visually-hidden">(for <%= organisation.name %>)</span>
-                                        </a>
-                                        <div class="meta govuk-visually-hidden">
-                                            <div class="approvers">
-                                                <dl class="inline condensed small-dt">
+                                        <div class="dfe-custom-details-component">
+                                            <details class="govuk-details govuk-!-font-size-16">
+                                                <summary class="govuk-details__summary">
+                                                    <span class="govuk-details__summary-text" data-open="Hide approvers" data-close="Show approvers">
+                                                    </span>
+                                                </summary>
+                                                <div class="govuk-details__text">
                                                     <ul>
                                                         <% for (let a = 0; a < organisation.approvers.length; a++) { %>
-                                                            <li><%= organisation.approvers[a].email %></li>
+                                                            <li>
+                                                                <%= organisation.approvers[a].email %>
+                                                            </li>
                                                         <% } %>
                                                     </ul>
-                                                </dl>
-                                            </div>
+                                                </div>
+                                            </details>
                                         </div>
                                     <% } %>
                                 </td>
                             </tr>
                         <% } %>
-
                     </tbody>
                 </table>
-
             <% } %>
         </div>
     </div>


### PR DESCRIPTION
## Summary
**Jira ticket:** https://dfe-secureaccess.atlassian.net/browse/DSI-7053
## Changes
- Enclosed the approvers list within a details component in the user's organisations table

## Related PRs
https://github.com/DFE-Digital/login.dfe.ui-toolkit/pull/130