### PR TITLE
[NSA-8480] Make tls option for redis configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ npm install
 
 ### Run application
 
-This application requires redis to run.  The easiest way is to create an instance of redis using docker:
+This application requires redis to run.  If running locally, the easiest way is to create an instance of redis using docker:
 
 ```
 docker run -d -p 6379:6379 redis
 ```
 
-**Important note when running locally** - Connecting to local redis will fail unless `tls` is set to `false` in src/index.js L34.  Currently, even setting `tls=false` in the connection string doesn't help.  This will be fixed in the future, but for now this is a workaround for it.
+Once redis is running, start it with:
 
 ```
 npm run dev

--- a/src/index.js
+++ b/src/index.js
@@ -28,16 +28,19 @@ https.globalAgent.maxSockets = http.globalAgent.maxSockets = config.hostingEnvir
 configSchema.validate();
 
 // Initialize client.
+const redisUrl = new URL(config.cookieSessionRedis.params.connectionString);
+const tlsParam = redisUrl.searchParams.get('tls');
+const tlsParamBoolean = (typeof tlsParam === 'string') ? (tls.toLowerCase() === 'true') : false;
 let redisClient = createClient({
   url: config.cookieSessionRedis.params.connectionString,
   socket: {
-    tls: true
+    tls: tlsParamBoolean,
   }
 });
 
 // Initialize store.
 let redisStore = new RedisStore({
-  client: redisClient, 
+  client: redisClient,
   prefix: 'CookieSession:',
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ configSchema.validate();
 // Initialize client.
 const redisUrl = new URL(config.cookieSessionRedis.params.connectionString);
 const tlsParam = redisUrl.searchParams.get('tls');
-const tlsParamBoolean = (typeof tlsParam === 'string') ? (tls.toLowerCase() === 'true') : false;
+const tlsParamBoolean = (typeof tlsParam === 'string') ? (tlsParam.toLowerCase() === 'true') : false;
 let redisClient = createClient({
   url: config.cookieSessionRedis.params.connectionString,
   socket: {


### PR DESCRIPTION
Previously you'd have to change the tls option in `index.js` by hand to run it locally.  This PR makes redis respect the tls value passed in via the url