### PR TITLE
[NSA-8502] Remove Pirean migration links

### DIFF
--- a/DevOps/templates/template.json
+++ b/DevOps/templates/template.json
@@ -116,20 +116,6 @@
                 "description": "Whether or not to include a staging deployment slot"
             }
         },
-         "pireanServices": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Add app settings to support the display of warning messages for pirean services"
-            }
-        },
-        "pireanservicesactivelink": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Active link for services"
-            }
-        },
          "emailValidation": {
             "type": "bool",
             "defaultValue": true,
@@ -183,8 +169,6 @@
                             "TOPIC_NAME": "[parameters('auditServiceBusTopicName')]",
                             "SUBSCRIPTION_NAME": "[parameters('auditServiceBusSubscriptionName')]",
                             "WEBSITE_HEALTHCHECK_MAXPINGFAILURES": "4",
-                            "PIREAN_SERVICES": "[parameters('pireanServices')]",
-                            "PIREAN_SERVICES_ACTIVE_LNK": "[parameters('pireanservicesactivelink')]",
                             "emailValidation": "[parameters('emailValidation')]",
                             "WEBSITE_LOCAL_CACHE_OPTION": "Always",
                             "WEBSITE_LOCAL_CACHE_SIZEINMB": "2000"

--- a/README.md
+++ b/README.md
@@ -46,16 +46,15 @@ npm run test
 10. Add aad shd app id to keyvault with name `aadshdappid` - added
 11. Add cdn Host Name to keyvault with name `cdnHostName` - added
 12. Add cdn Assets Version to keyvault with name `cdnAssetsVersion` - added
-13. Add pirean Services to keyvault with name `pireanServices` - added also in azure devops variable group
-14. Add Directories host name to keyvault with name `standaloneDirectoriesHostName` - added
-15. Add support host name to keyvault with name `standaloneSupportHostName` - added
-16. Add Devices host name to keyvault with name `standaloneDevicesHostName` - added
-17. Add Organisations host name to keyvault with name `standaloneOrganisationsHostName` - added
-18. Add Applications host name to keyvault with name `standaloneApplicationsHostName` - added
-19. Add Access host name to keyvault with name `standaloneAccessHostName` - added
-20. Add profile host name to keyvault with name `standaloneProfileHostName` - added
-21. Add services host name to keyvault with name `standaloneServicesHostName` - added
-22. Add Oidc host name to keyvault with name `standaloneOidcHostName` - added
-23. Add help host name to keyvault with name `standaloneHelpHostName` - added
-24. Add Interactions host name to keyvault with name `standaloneInteractionsHostName` - added
-25. Add service Id to keyvault with name `serviceId` - added
+13. Add Directories host name to keyvault with name `standaloneDirectoriesHostName` - added
+14. Add support host name to keyvault with name `standaloneSupportHostName` - added
+15. Add Devices host name to keyvault with name `standaloneDevicesHostName` - added
+16. Add Organisations host name to keyvault with name `standaloneOrganisationsHostName` - added
+17. Add Applications host name to keyvault with name `standaloneApplicationsHostName` - added
+18. Add Access host name to keyvault with name `standaloneAccessHostName` - added
+19. Add profile host name to keyvault with name `standaloneProfileHostName` - added
+20. Add services host name to keyvault with name `standaloneServicesHostName` - added
+21. Add Oidc host name to keyvault with name `standaloneOidcHostName` - added
+22. Add help host name to keyvault with name `standaloneHelpHostName` - added
+23. Add Interactions host name to keyvault with name `standaloneInteractionsHostName` - added
+24. Add service Id to keyvault with name `serviceId` - added

--- a/src/app/home/getServices.js
+++ b/src/app/home/getServices.js
@@ -24,15 +24,10 @@ const { getApproverOrgsFromReq, isUserEndUser, isLoginOver24 } = require('../use
 const { actions } = require('../constans/actions');
 const flash = require('login.dfe.express-flash-2');
 
-const pireanServices = process.env.PIREAN_SERVICES ? process.env.PIREAN_SERVICES.split(',') : [];
-const pireanServicesActiveLink = process.env.PIREAN_SERVICES_ACTIVE_LNK
-  ? process.env.PIREAN_SERVICES_ACTIVE_LNK.split(',')
-  : [];
 let user = null;
 
 const getAndMapServices = async (account, correlationId) => {
   user = await Account.getById(account.id);
-  const isMigrated = user && user.claims ? user.claims.isMigrated : false;
   const serviceAccess = (await getServicesForUser(account.id, correlationId)) || [];
   let services = serviceAccess.map((sa) => ({
     id: sa.serviceId,
@@ -85,16 +80,6 @@ const getAndMapServices = async (account, correlationId) => {
     }
   }
 
-  // temporary disabled myesf service for users who were invited
-  if (isMigrated) {
-    services.push({
-      name: 'Manage Your Education and Skills Funding',
-      description:
-        "Use this service to: sign documents, view your funding allocations, view the funding you've received, manage apprenticeship details, and tell us about subcontractors",
-      disabled: true,
-      date: '18 March 2020',
-    });
-  }
   return sortBy(services, 'name');
 };
 
@@ -289,7 +274,6 @@ const getServices = async (req, res) => {
     },
   });
 
-  const userPireanServices = services.filter((value) => pireanServices.includes(value.name));
   const newServiceBanner = await fetchNewServiceBanners(req.user.id, 5);
   let newAddedServiceBanner = [];
   if (newServiceBanner !== null && newServiceBanner !== undefined && newServiceBanner.length > 0) {
@@ -320,9 +304,6 @@ const getServices = async (req, res) => {
     isRequestServiceAllowed,
     passwordChangedBanner,
     showJobTitleBanner,
-    pireanServices,
-    userPireanServices,
-    pireanServicesActiveLink,
     subServiceAddedBanners,
   });
 };

--- a/src/app/home/views/services.ejs
+++ b/src/app/home/views/services.ejs
@@ -21,40 +21,6 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds govuk-!-padding-0">
                 <div class="govuk-!-margin-top-9 govuk-!-margin-bottom-9">
-                    <% if(locals.userPireanServices.length > 1)  { %>
-                        <div class="govuk-warning-text">
-                            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                            <strong class="govuk-warning-text__text">
-                                <span class="govuk-warning-text__assistive">Warning</span>
-                                <p>
-                                    The following services are moving from IDAMS to DfE Sign-in. You can only access the services from this page once they have moved:
-                                    <ul class="govuk-list govuk-list--bullet">
-                                    <% for (let j = 0; j < locals.userPireanServices.length; j++) { %>
-                                        <li> <%=locals.userPireanServices[j].name; %> </li>
-                                    <% } %>
-                                    </ul>
-                                </p>
-                                <p>
-                                    All services will have moved from IDAMS to DfE Sign-in by mid-2024. If the service is not listed below, visit the <a href="https://logon.fasst.org.uk/">IDAMS sign in page</a> to access it.
-                                </p>
-                            </strong>
-                        </div>
-                    <%}%>
-                    <% if(locals.userPireanServices.length === 1) { %>
-                        <div class="govuk-warning-text">
-                            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                            <strong class="govuk-warning-text__text">
-                                <span class="govuk-warning-text__assistive">Warning</span>
-                                <p>
-                                    <%=locals.userPireanServices[0].name%> is moving from IDAMS to DfE Sign-in.
-                                    Some roles and institutions are currently available on DfE Sign-in and others are on IDAMS. Sign in as normal by selecting your institution or role from the list within VYED. Depending on what you select from the list, you may have to use your IDAMS username and password to access.
-                                </p>
-                                <p>
-                                    After the move, you will be able to access VYED from this page without logging in again.
-                                </p>
-                            </strong>
-                        </div>
-                    <% } %>
                     <% if (locals.newAddedServiceBanner) { %>
                         <%  locals.newAddedServiceBanner.forEach((item) => { %>
                             <div id="notification-wrapper-service-added" class="govuk-notification-banner govuk-notification-banner--success"
@@ -482,28 +448,15 @@
                         </tr>
                     </thead>
                     <tbody class="govuk-table__body">
-                        <%
-                            const p_services = locals.pireanServices.map(element => {
-                                return element.toLowerCase();
-                            });
-                            const p_services_active_lnk = locals.pireanServicesActiveLink.map(element => {
-                                return element.toLowerCase();
-                            });
-                                for (let s = 0; s < services.length; s++) {
-                                    const service = services[s];
-                                %>
+                    <%
+                        for (let s = 0; s < services.length; s++) {
+                            const service = services[s];
+                    %>
                         <tr class="govuk-table__row">
                             <td class="govuk-table__cell">
-                                <p class="<%= service.disabled ? 'service-link-disabled' : 'service-link'%>">
-                                    <% if (service.disabled) { %>
-                                    <span class="date">Available: <%=service.date%></span>
-                                    <h3 class="govuk-heading-s"><%=service.name%></h3>
-                                <% } else if(p_services.includes(service.name.toLowerCase()) && !p_services_active_lnk.includes(service.name.toLowerCase())){ %>
-                                <h3 class="govuk-heading-s"><%=service.name%></h3>
-                                    <% } else { %>
-                                        <a href="<%=service.serviceUrl%>" class="govuk-link-bold"
-                                        target="_blank"><%=service.name%></a>
-                                    <% } %>
+                                <p class="service-link">
+                                    <a href="<%=service.serviceUrl%>" class="govuk-link-bold"
+                                    target="_blank"><%=service.name%></a>
                                 </p>
                             </td>
                             <td class="govuk-table__cell">
@@ -533,7 +486,7 @@
                                 </div>
                             </td>
                         </tr>
-                        <% } %>
+                    <% } %>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
Ticket: https://dfe-secureaccess.atlassian.net/browse/NSA-8502

- Removes the `pireanServices` and `pireanservicesactivelink` parameters from the DevOps template and the README file, as the key vault values are no longer needed.
- Removes the bug-causing additional service that was put in for `isMigrated` users (`src/app/home/getServices.js` lines 88 - 97) as it was from 2020, the service is now onboarded, and is not linked to an organisation so caused an error for migrated users.
- Removed the `pireanServices` and `pireanservicesactivelink` code from the `getServices.js` file, as all the services have been migrated.
- Removed markup from the "my-services" (`services.ejs`) page relating to the completed Pirean migration, including any banners or listed "coming soon" services.