### PR TITLE
[DSI-7197] Mandate a reason when rejecting a service request

### DIFF
--- a/src/app/accessRequests/rejectServiceRequest.js
+++ b/src/app/accessRequests/rejectServiceRequest.js
@@ -30,8 +30,10 @@ const getViewModel = (req) => {
 const validate = async (req) => {
   let model = getViewModel(req);
   model.request = await getAndMapServiceRequest(req.params.rid);
-  model.reason = req.body.reason;
-  if (model.reason.length > 1000) {
+  model.reason = req.body.reason?.trim() ?? '';
+  if (model.reason.length === 0) {
+    model.validationMessages.reason = 'Enter a reason for rejection';
+  } else if (model.reason.length > 1000) {
     model.validationMessages.reason = 'Reason cannot be longer than 1000 characters';
   }
   return model;

--- a/src/app/accessRequests/views/rejectServiceRequest.ejs
+++ b/src/app/accessRequests/views/rejectServiceRequest.ejs
@@ -14,12 +14,13 @@
                     </legend>
 
                     <div class="govuk-form-group <%= (locals.validationMessages.reason !== undefined) ? 'govuk-form-group--error' : '' %>">
-                        <label class="govuk-label govuk-label--s" for="reason">Reason for rejection (optional) </label>
                         <% if (locals.validationMessages.reason !== undefined) { %>
                             <span id="validation-reason" class="govuk-error-message">
                                 <span class="govuk-visually-hidden">Error:</span> <%=locals.validationMessages.reason %>
                             </span>
-                        <% } %>
+                            <% } else { %>
+                                <label class="govuk-label govuk-label--s" for="reason">Reason for rejection</label>
+                            <% } %>
                         <textarea class="govuk-textarea govuk-!-width-full" rows="6" id="reason" name="reason"
                         <% if (locals.validationMessages.reason !== undefined) { %>
                                     aria-invalid="true" aria-describedby="validation-reason"

--- a/src/app/requestService/rejectServiceRequest.js
+++ b/src/app/requestService/rejectServiceRequest.js
@@ -16,6 +16,7 @@ const notificationClient = new NotificationClient({
 const { checkCacheForAllServices } = require('../../infrastructure/helpers/allServicesAppCache');
 
 const { getUserServiceRequestStatus, updateServiceRequest } = require('./utils.js');
+
 const getViewModel = async (req) => {
   const organisationDetails = req.userOrganisations.find((x) => x.organisation.id === req.params.orgId);
   const serviceId = req.params.sid;
@@ -111,8 +112,7 @@ const post = async (req, res) => {
   if (!req.session.user) {
     return res.redirect('/my-services');
   }
-  let rejectReason = req.body.reason ? req.body.reason : "";
-
+  
   const model = await getViewModel(req)
   const roleIds = JSON.parse(decodeURIComponent(req.params.rids))
   const roles = roleIds || [];
@@ -127,6 +127,12 @@ const post = async (req, res) => {
 
   if (policyValidationResult.length > 0) {
     model.validationMessages.roles = policyValidationResult.map((x) => x.message)
+    return res.render('requestService/views/rejectServiceRequest', model)
+  }
+
+  const rejectReason = (req.body.reason ? req.body.reason : "").trim();
+  if (rejectReason.length > 1000 || rejectReason.length === 0) {
+    model.validationMessages.reason = rejectReason.length > 1000 ? 'Reason cannot be longer than 1000 characters' : 'Enter a reason for rejection' ;
     return res.render('requestService/views/rejectServiceRequest', model)
   }
 

--- a/src/app/requestService/views/rejectServiceRequest.ejs
+++ b/src/app/requestService/views/rejectServiceRequest.ejs
@@ -64,11 +64,24 @@
 
             <form method="post" id="form-deactivate" class="prevent-form-double-submission">
                 <input type="hidden" name="_csrf" value="<%= csrfToken %>" />
-                <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-                    Reason for rejection (optional)
+                <h2 class="govuk-heading-m">
+                    Reason for rejection
                 </h2>
-                <p class="govuk-caption-l govuk-!-margin-top-0">Reason will be shared with requestee via email</p>
-                <textarea class="govuk-textarea govuk-!-width-full" rows="6" id="reason" name="reason"></textarea>
+                <div class="govuk-form-group <%= (locals.validationMessages.reason !== undefined) ? 'govuk-form-group--error' : '' %>">
+                    <p class="govuk-caption-m govuk-!-margin-bottom-1">This information will be shared with the requester via email.</p>
+                    
+                    <% if (locals.validationMessages.reason !== undefined) { %>
+                        <span id="validation-reason" class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error:</span> <%=locals.validationMessages.reason %>
+                        </span>
+                    <% } %>
+
+                    <textarea class="govuk-textarea govuk-!-width-full" rows="6" id="reason" name="reason"
+                        <% if (locals.validationMessages.reason !== undefined) { %>
+                                    aria-invalid="true" aria-describedby="validation-reason"
+                                <% } %>
+                                    value="<%= locals.reason %>"></textarea>
+                </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button">Reject request</button>
                     <a href="/my-services" class="govuk-button govuk-button--secondary">Cancel</a>

--- a/test/unit/app/accessRequests/rejectServiceRequest.post.test.js
+++ b/test/unit/app/accessRequests/rejectServiceRequest.post.test.js
@@ -1,4 +1,4 @@
-const { listRolesOfService, addUserService } = require('../../../../src/infrastructure/access');
+const { listRolesOfService } = require('../../../../src/infrastructure/access');
 const { mockRequest, mockResponse, mockAdapterConfig, mockLogger } = require('../../../utils/jestMocks');
 const { getAndMapServiceRequest, generateFlashMessages } = require('../../../../src/app/accessRequests/utils');
 const { post } = require('../../../../src/app/accessRequests/rejectServiceRequest');
@@ -201,6 +201,51 @@ describe('when reviewing a service request', () => {
     expect(res.render.mock.calls[0][1]).toMatchObject({
       validationMessages: {
         reason: 'Reason cannot be longer than 1000 characters',
+      },
+    });
+  });
+
+  it('then it should render error view if rejection reason has been provided with empty spaces', async () => {
+    req.body.reason = '   ';
+
+    await post(req, res);
+
+    expect(updateServiceRequest.mock.calls).toHaveLength(0);
+    expect(res.render.mock.calls).toHaveLength(1);
+    expect(res.render.mock.calls[0][0]).toBe('accessRequests/views/rejectServiceRequest');
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      validationMessages: {
+        reason: 'Enter a reason for rejection',
+      },
+    });
+  });
+
+  it('then it should render error view if rejection reason has not been provided', async () => {
+    req.body.reason = '';
+
+    await post(req, res);
+
+    expect(updateServiceRequest.mock.calls).toHaveLength(0);
+    expect(res.render.mock.calls).toHaveLength(1);
+    expect(res.render.mock.calls[0][0]).toBe('accessRequests/views/rejectServiceRequest');
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      validationMessages: {
+        reason: 'Enter a reason for rejection',
+      },
+    });
+  });
+
+  it('then it should render error view if rejection reason is null', async () => {
+    req.body.reason = null;
+
+    await post(req, res);
+
+    expect(updateServiceRequest.mock.calls).toHaveLength(0);
+    expect(res.render.mock.calls).toHaveLength(1);
+    expect(res.render.mock.calls[0][0]).toBe('accessRequests/views/rejectServiceRequest');
+    expect(res.render.mock.calls[0][1]).toMatchObject({
+      validationMessages: {
+        reason: 'Enter a reason for rejection',
       },
     });
   });

--- a/test/unit/app/requestService/rejectServiceRequest.post.test.js
+++ b/test/unit/app/requestService/rejectServiceRequest.post.test.js
@@ -1,0 +1,204 @@
+jest.mock('login.dfe.policy-engine');
+jest.mock('login.dfe.notifications.client');
+jest.mock('./../../../../src/infrastructure/config', () => require('./../../../utils/jestMocks').mockConfig());
+jest.mock('./../../../../src/infrastructure/logger', () => require('./../../../utils/jestMocks').mockLogger());
+
+const NotificationClient = require('login.dfe.notifications.client');
+const {updateServiceRequest} = require('../../../../src/app/requestService/utils');
+const PolicyEngine = require('login.dfe.policy-engine');
+const { checkCacheForAllServices } = require('./../../../../src/infrastructure/helpers/allServicesAppCache');
+const { getUserDetails } = require('../../../../src/app/users/utils');
+const logger = require('./../../../../src/infrastructure/logger');
+
+const policyEngine = {
+  getPolicyApplicationResultsForUser: jest.fn(),
+  validate: jest.fn(),
+};
+
+NotificationClient.mockImplementation(() => {
+  return {
+    sendServiceRequestRejected: jest.fn(),
+  };
+});
+
+jest.mock('../../../../src/app/requestService/utils', () => {
+  return {
+    updateServiceRequest: jest.fn(),
+  };
+});
+
+jest.mock('./../../../../src/infrastructure/helpers/allServicesAppCache', () => {
+  return {
+    checkCacheForAllServices: jest.fn(),
+  };
+});
+
+jest.mock('../../../../src/app/users/utils', () => {
+  return {
+    getUserDetails: jest.fn(),
+  };
+});
+
+jest.mock('login.dfe.dao', () => {
+  return {
+    services: {
+    },
+    directories: {
+    },
+  };
+});
+
+describe('when posting a service rejection', () => {
+  let req;
+  let res;
+
+  let postRejectServiceRequest;
+
+  beforeEach(() => {
+    req = {
+      body: {},
+      user: {
+        uid: 'mock-uid',
+        email: 'mock-email',
+        sub: 'mock-sub',
+      },
+      session: {
+        user: {
+          firstName: 'mock-first-name',
+          lastName: 'mock-last-name',
+          email: 'mock-email',
+          uid: 'mock-uid',
+        },
+      },
+      csrfToken: jest.fn(),
+      params: {
+        sid: 'service1',
+        orgId: 'organisationId',
+        rids: [0],
+      },
+      query: {},
+      userOrganisations: [
+        {
+          organisation: {
+            id: 'organisationId',
+            name: 'organisationName',
+          },
+          role: {
+            id: 0,
+            name: 'category name',
+          },
+        },
+      ],
+    };
+    
+    res = {
+      status: jest.fn(),
+      redirect: jest.fn(),
+      render: jest.fn(),
+      flash: jest.fn(),
+    };
+
+    checkCacheForAllServices.mockReset();
+    checkCacheForAllServices.mockReturnValue({
+      services: [
+        {
+          id: 'service1',
+          name: 'service name',
+        },
+      ],
+    });
+
+    getUserDetails.mockReset();
+    getUserDetails.mockReturnValue({
+      id: 'user1',
+      email: 'email@email.com',
+      firstName: 'test',
+      lastName: 'name',
+    });
+
+    updateServiceRequest.mockReset();
+    updateServiceRequest.mockReturnValue(request = {success : true});
+
+    policyEngine.validate.mockReset().mockReturnValue([]);
+    PolicyEngine.mockReset().mockImplementation(() => policyEngine);
+
+    postRejectServiceRequest = require('../../../../src/app/requestService/rejectServiceRequest').post;
+  });
+
+  it('should redirect to /my-services when there is no session', async () => {
+    req.session.user = undefined;
+
+    await postRejectServiceRequest(req, res);
+    expect(res.redirect).toHaveBeenCalledWith('/my-services');
+  });
+
+
+  it('should render rejectServiceRequest when a request contains no reason in the body', async () => {
+    
+    await postRejectServiceRequest(req, res);
+    expect(res.render.mock.calls[0][0]).toBe('requestService/views/rejectServiceRequest');
+    expect(res.render.mock.calls[0][1]).toEqual(expect.objectContaining({
+      validationMessages: {
+        reason: 'Enter a reason for rejection',
+      },
+    }));
+  });
+
+  it('should render rejectServiceRequest when a request contains and empty reason in the body', async () => {
+    req.body.reason = '';
+
+    await postRejectServiceRequest(req, res);
+    expect(res.render.mock.calls[0][0]).toBe('requestService/views/rejectServiceRequest');
+    expect(res.render.mock.calls[0][1]).toEqual(expect.objectContaining({
+      validationMessages: {
+        reason: 'Enter a reason for rejection',
+      },
+    }));
+  });
+
+  it('should render rejectServiceRequest when a request contains a space padded reason in the body', async () => {
+    req.body.reason = '     ';
+
+    await postRejectServiceRequest(req, res);
+    expect(res.render.mock.calls[0][0]).toBe('requestService/views/rejectServiceRequest');
+    expect(res.render.mock.calls[0][1]).toEqual(expect.objectContaining({
+      validationMessages: {
+        reason: 'Enter a reason for rejection',
+      },
+    }));
+  });
+  
+  it('should render rejectServiceRequest with \'Reason cannot be longer than 1000 characters\'', async () => {
+    req.body.reason = 'x'.repeat(1001);
+
+    await postRejectServiceRequest(req, res);
+    expect(res.render.mock.calls[0][0]).toBe('requestService/views/rejectServiceRequest');
+    expect(res.render.mock.calls[0][1]).toEqual(expect.objectContaining({
+      validationMessages: {
+        reason: 'Reason cannot be longer than 1000 characters',
+      },
+    }));
+  });
+
+  it('should succeed and redirect to /my-services', async () => {
+    req.body.reason = 'x'.repeat(10);
+
+    await postRejectServiceRequest(req, res);
+
+    expect(res.redirect).toHaveBeenCalledWith('/my-services');
+    expect(res.flash.mock.calls[0]).toEqual(expect.arrayContaining(['title', 'Success']));
+    expect(res.flash.mock.calls[1]).toEqual(expect.arrayContaining(['heading', 'Request rejected successfully']));
+    expect(res.flash.mock.calls[2]).toEqual(expect.arrayContaining(['message', 'An email will be sent to the requestee informing them of their request rejection.']));
+
+    expect(logger.audit).toHaveBeenCalledWith({
+      application: undefined,
+      env: 'test-run',
+      message: 'mock-email (approverId: mock-sub) rejected service (serviceId: service1), roles (roleIds: []) and organisation (orgId: organisationId) for end user (endUserId: undefined). The reject reason is xxxxxxxxxx - requestId (reqId: undefined)',
+      subType: 'access-request-rejected',
+      type: 'services',
+      userEmail: 'mock-email',
+      userId: 'mock-uid',
+    });
+  });
+  
+});


### PR DESCRIPTION
### Summary
Jira ticket: [DSI-7197](https://dfe-secureaccess.atlassian.net/browse/DSI-7197)

### Changes
- modified `src/app/accessRequests/rejectServiceRequest.js` so that an empty/blank reason is rejected
- modified `src/app/accessRequests/views/rejectServiceRequest.ejs` to show validation error(s)
- modified `src/app/requestService/rejectServiceRequest.js` so that an empty/blank reason is rejected
- modified `src/app/requestService/views/rejectServiceRequest.ejs` to show validation error(s)
- Updated and added additional test coverage