### PR TITLE
Feature/nsa 8339 disable cross origin opener policy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,7 @@ const init = async () => {
   const self = "'self'";
   const allowedOrigin = '*.signin.education.gov.uk';
 
+
   const scriptSources = [self, "'unsafe-inline'", "'unsafe-eval'", allowedOrigin];
   const styleSources = [self, "'unsafe-inline'", allowedOrigin];
   const imgSources = [self, 'data:', 'blob:', allowedOrigin];
@@ -91,17 +92,22 @@ const init = async () => {
     fontSources.push('localhost');
   }
 
-  app.use(helmet.contentSecurityPolicy({
-    directives: {
-      defaultSrc: [self],
-      scriptSrc: scriptSources,
-      styleSrc: styleSources,
-      imgSrc: imgSources,
-      fontSrc: fontSources,
-      connectSrc: [self],
-      formAction: [self, '*'],
-    },
-  }));
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: [self],
+          scriptSrc: scriptSources,
+          styleSrc: styleSources,
+          imgSrc: imgSources,
+          fontSrc: fontSources,
+          connectSrc: [self],
+          formAction: [self, '*'],
+        },
+      },
+      crossOriginOpenerPolicy: { policy: "unsafe-none" }, // crossOriginOpenerPolicy: false is ignored and unsafe-none is the default on MDM
+    }),
+  );
 
   logger.info('Set helmet filters');
 


### PR DESCRIPTION
Disable Cross-Origin-Opener-Policy which was inadvertently introduced and set to same-origin by helmetjs

'crossOriginOpenerPolicy: false' is being ignored by helmet (despite their documentation) - it sets same-origin and unsafe-none is the default on MDM. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy