### PR TITLE
[NSA-8595] Fix session variables not being saved with redirects

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,12 @@
 {
   module.exports = {
-    parser: 'babel-eslint', // Specifies the ESLint parser
     parserOptions: {
-        ecmaVersion: 2020, // Allows for the parsing of modern ECMAScript features
-        sourceType: 'module', // Allows for the use of imports
+      ecmaVersion: 2020, // Allows for the parsing of modern ECMAScript features
+      sourceType: 'module', // Allows for the use of imports
     },
     plugins: ['prettier'],
     rules: {
-        'prettier/prettier': 'error',
+      'prettier/prettier': 'error',
     },
-  }
-};
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "agentkeepalive": "^4.5.0",
         "applicationinsights": "^2.0.0",
-        "babel-eslint": "^10.1.0",
         "body-parser": "^1.18.1",
         "connect-redis": "^7.1.1",
         "cookie-parser": "^1.4.3",
@@ -423,6 +422,7 @@
       "version": "7.24.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/code-frame/-/code-frame-7.24.7.tgz",
       "integrity": "sha1-iC/Z4J6O4yTklr0EBAHG8EbvRGU=",
+      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.24.7",
         "picocolors": "^1.0.0"
@@ -483,6 +483,7 @@
       "version": "7.25.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/generator/-/generator-7.25.6.tgz",
       "integrity": "sha1-DfGtjLMv5NKwHYv0N/FT0ZNCqHw=",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.25.6",
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -613,6 +614,7 @@
       "version": "7.24.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/highlight/-/highlight-7.24.7.tgz",
       "integrity": "sha1-oFqx3xNLKGVYquDtQebF9zG/QJ0=",
+      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
@@ -863,6 +865,7 @@
       "version": "7.25.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/template/-/template-7.25.0.tgz",
       "integrity": "sha1-5zPcMTS0/t5SjBW8leicuYxSWSo=",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
         "@babel/parser": "^7.25.0",
@@ -876,6 +879,7 @@
       "version": "7.25.6",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/traverse/-/traverse-7.25.6.tgz",
       "integrity": "sha1-BPrZgORE8YLs8VIFBJQZQKkP6kE=",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
         "@babel/generator": "^7.25.6",
@@ -1795,6 +1799,7 @@
       "version": "0.3.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha1-3M5q/3S99trRqVgCtpsEovyx+zY=",
+      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1808,6 +1813,7 @@
       "version": "3.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha1-eg7mAfYPmaIMfHxf8MgDiMEYm9Y=",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1816,6 +1822,7 @@
       "version": "1.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha1-VY+2Ry7RakyFC4iVMOazZDjEkoA=",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1823,12 +1830,14 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha1-MYi8snOkFLDSFf0ipYVAuYm5QJo="
+      "integrity": "sha1-MYi8snOkFLDSFf0ipYVAuYm5QJo=",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha1-FfGQ6YiV8/wjJ27hS8drZ1wuUPA=",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -2440,6 +2449,7 @@
       "version": "3.2.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -2698,25 +2708,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha1-aWjlaKkQt4+zd5zdi2rC9HmUMjI=",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "eslint": ">= 4.12.1"
       }
     },
     "node_modules/babel-jest": {
@@ -3158,6 +3149,7 @@
       "version": "2.4.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -4113,6 +4105,7 @@
       "version": "1.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -4349,14 +4342,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/eslint/node_modules/ansi-styles": {
@@ -5175,6 +5160,7 @@
       "version": "11.12.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/globals/-/globals-11.12.0.tgz",
       "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -5230,6 +5216,7 @@
       "version": "3.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -7642,7 +7629,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
+      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -7659,6 +7647,7 @@
       "version": "2.5.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
+      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -8901,7 +8890,8 @@
     "node_modules/picocolors": {
       "version": "1.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha1-U1i3anjN5IO6XO9qnclnFECyfVk="
+      "integrity": "sha1-U1i3anjN5IO6XO9qnclnFECyfVk=",
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -10278,6 +10268,7 @@
       "version": "5.5.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "agentkeepalive": "^4.5.0",
     "applicationinsights": "^2.0.0",
-    "babel-eslint": "^10.1.0",
     "body-parser": "^1.18.1",
     "connect-redis": "^7.1.1",
     "cookie-parser": "^1.4.3",

--- a/src/app/requestOrganisation/review.js
+++ b/src/app/requestOrganisation/review.js
@@ -95,7 +95,7 @@ const post = async (req, res) => {
     res.flash('heading', `Your request has been sent to the DfE Sign-in Helpdesk.`);
     res.flash('message', `There are no approvers at ${req.body.organisationName} so your request has been forwarded to the DfE Sign-in Helpdesk.`);
   }
-  return res.redirect('/organisations');
+  return res.sessionRedirect('/organisations');
 };
 
 module.exports = {

--- a/src/app/requestOrganisation/selectOrganisation.js
+++ b/src/app/requestOrganisation/selectOrganisation.js
@@ -85,7 +85,7 @@ const post = async (req, res) => {
       return res.render('requestOrganisation/views/search', model);
     }
     req.session.organisationId = req.body.selectedOrganisation;
-    return res.redirect('review');
+    return res.sessionRedirect('review');
   }
   return res.render('requestOrganisation/views/search', model);
 };

--- a/src/app/requestService/confirmServiceRequest.js
+++ b/src/app/requestService/confirmServiceRequest.js
@@ -26,6 +26,11 @@ const get = async (req, res) => {
     return res.redirect('/my-services');
   }
 
+  if (!Array.isArray(req.session.user.services) || req.session.user.services.length === 0) {
+    logger.warn(`GET ${req.originalUrl} missing user session services, redirecting to my-services`);
+    return res.redirect('/my-services');
+  }
+
   const organisationDetails = req.userOrganisations.find((x) => x.organisation.id === req.params.orgId);
   const services = req.session.user.services.map((service) => ({
     id: service.serviceId,
@@ -66,6 +71,11 @@ const get = async (req, res) => {
 
 const post = async (req, res) => {
   if (!req.session.user) {
+    return res.redirect('/my-services');
+  }
+
+  if (!Array.isArray(req.session.user.services) || req.session.user.services.length === 0) {
+    logger.warn(`POST ${req.originalUrl} missing user session services, redirecting to my-services`);
     return res.redirect('/my-services');
   }
 

--- a/src/app/requestService/requestEditRoles.js
+++ b/src/app/requestService/requestEditRoles.js
@@ -173,13 +173,13 @@ const post = async (req, res) => {
           }
         } else {
           saveRoleInSession(req, selectedRoles);
-          return res.redirect(`${req.params.sid}/confirm-edit-roles-request`);
+          return res.sessionRedirect(`${req.params.sid}/confirm-edit-roles-request`);
         }
       }
     } else {
       saveRoleInSession(req, selectedRoles);
 
-      return res.redirect(`${req.params.sid}/confirm-edit-roles-request`);
+      return res.sessionRedirect(`${req.params.sid}/confirm-edit-roles-request`);
     }
   }
 };

--- a/src/app/requestService/requestRoles.js
+++ b/src/app/requestService/requestRoles.js
@@ -112,7 +112,7 @@ const post = async (req, res) => {
     return renderAssociateRolesPage(req, res, model);
   }
 
-  return res.redirect(`/request-service/${req.params.orgId}/users/${req.user.sub}/confirm-request`);
+  return res.sessionRedirect(`/request-service/${req.params.orgId}/users/${req.user.sub}/confirm-request`);
 };
 
 module.exports = {

--- a/src/app/requestService/requestRoles.js
+++ b/src/app/requestService/requestRoles.js
@@ -4,6 +4,7 @@ const { isMultipleRolesAllowed, RoleSelectionConstraintCheck } = require('../use
 const { getApplication } = require('../../infrastructure/applications');
 const { getOrganisationAndServiceForUserV2 } = require('../../infrastructure/organisations');
 const PolicyEngine = require('login.dfe.policy-engine');
+const logger = require('../../infrastructure/logger');
 const policyEngine = new PolicyEngine(config);
 const renderAssociateRolesPage = (_req, res, model) => {
   return res.render('requestService/views/requestRoles', model);
@@ -74,12 +75,22 @@ const get = async (req, res) => {
     return res.redirect('/my-services');
   }
 
+  if (!Array.isArray(req.session.user.services) || req.session.user.services.length === 0) {
+    logger.warn(`GET ${req.originalUrl} missing user session services, redirecting to my-services`);
+    return res.redirect('/my-services');
+  }
+
   const model = await getViewModel(req);
   return renderAssociateRolesPage(req, res, model);
 };
 
 const post = async (req, res) => {
   if (!req.session.user) {
+    return res.redirect('/my-services');
+  }
+
+  if (!Array.isArray(req.session.user.services) || req.session.user.services.length === 0) {
+    logger.warn(`POST ${req.originalUrl} missing user session services, redirecting to my-services`);
     return res.redirect('/my-services');
   }
 

--- a/src/app/requestService/requestService.js
+++ b/src/app/requestService/requestService.js
@@ -178,7 +178,9 @@ const post = async (req, res) => {
   }
 
   const service = req.session.user.services[0].serviceId;
-  return res.redirect(`/request-service/${req.session.user.organisation}/users/${req.user.sub}/services/${service}`);
+  return res.sessionRedirect(
+    `/request-service/${req.session.user.organisation}/users/${req.user.sub}/services/${service}`,
+  );
 };
 
 module.exports = {

--- a/src/app/users/associateRoles.js
+++ b/src/app/users/associateRoles.js
@@ -166,7 +166,7 @@ const get = async (req, res) => {
   }
 
   const model = await getViewModel(req);
-   return renderAssociateRolesPage(req, res, model);
+  return renderAssociateRolesPage(req, res, model);
 };
 
 const post = async (req, res) => {
@@ -206,10 +206,10 @@ const post = async (req, res) => {
 
   if (currentService < req.session.user.services.length - 1) {
     const nextService = currentService + 1;
-    return res.redirect(`${req.session.user.services[nextService].serviceId}`);
+    return res.sessionRedirect(`${req.session.user.services[nextService].serviceId}`);
   } else {
     const nextLink = buildNextLink(req, selectedRoles);
-    return res.redirect(`${nextLink}`);
+    return res.sessionRedirect(`${nextLink}`);
   }
 };
 

--- a/src/app/users/associateRoles.js
+++ b/src/app/users/associateRoles.js
@@ -14,6 +14,7 @@ const { getOrganisationAndServiceForUserV2 } = require('./../../infrastructure/o
 const PolicyEngine = require('login.dfe.policy-engine');
 const policyEngine = new PolicyEngine(config);
 const { actions } = require('../constans/actions');
+const logger = require('../../infrastructure/logger');
 
 const renderAssociateRolesPage = (req, res, model) => {
   const isSelfManage = isSelfManagement(req);
@@ -165,12 +166,22 @@ const get = async (req, res) => {
     return res.redirect('/approvals/users');
   }
 
+  if (!Array.isArray(req.session.user.services) || req.session.user.services.length === 0) {
+    logger.warn(`GET ${req.originalUrl} missing user session services, redirecting to approvals/users`);
+    return res.redirect('/approvals/users');
+  }
+
   const model = await getViewModel(req);
   return renderAssociateRolesPage(req, res, model);
 };
 
 const post = async (req, res) => {
   if (!req.session.user) {
+    return res.redirect('/approvals/users');
+  }
+
+  if (!Array.isArray(req.session.user.services) || req.session.user.services.length === 0) {
+    logger.warn(`POST ${req.originalUrl} missing user session services, redirecting to approvals/users`);
     return res.redirect('/approvals/users');
   }
 

--- a/src/app/users/associateServices.js
+++ b/src/app/users/associateServices.js
@@ -229,7 +229,7 @@ const post = async (req, res) => {
   }
 
   if (req.session.user.isInvite && model.selectedServices.length === 0) {
-    return res.redirect(
+    return res.sessionRedirect(
       req.params.uid
         ? `/approvals/${req.params.orgId}/users/${req.params.uid}/confirm-details`
         : `/approvals/${req.params.orgId}/users/confirm-new-user`,
@@ -242,14 +242,14 @@ const post = async (req, res) => {
   const isReviewServiceReqAmendServiceUrl = isReviewServiceReqAmendService(req);
 
   if(isRemoveUserServiceUrl) {
-    return res.redirect(`services/${service}/remove-service?manage_users=true&action=${actions.REMOVE_SERVICE}`);
+    return res.sessionRedirect(`services/${service}/remove-service?manage_users=true&action=${actions.REMOVE_SERVICE}`);
   }
   else if(isEditServiceUrl) {
-    return res.redirect(`services/${service}?manage_users=true&action=${actions.EDIT_SERVICE}`);
+    return res.sessionRedirect(`services/${service}?manage_users=true&action=${actions.EDIT_SERVICE}`);
   } else if (isReviewServiceReqAmendServiceUrl) {
-    return res.redirect(`associate-services/${service}?action=${actions.REVIEW_SERVICE_REQ_SERVICE}`);
+    return res.sessionRedirect(`associate-services/${service}?action=${actions.REVIEW_SERVICE_REQ_SERVICE}`);
   }
-  return res.redirect(`associate-services/${service}`);
+  return res.sessionRedirect(`associate-services/${service}`);
 };
 
 module.exports = {

--- a/src/app/users/editServices.js
+++ b/src/app/users/editServices.js
@@ -165,7 +165,7 @@ const post = async (req, res) => {
      nexturl += '?manage_users=true';
     }
 
-  return res.redirect(nexturl);
+  return res.sessionRedirect(nexturl);
 };
 
 const saveRoleInSession = (req, selectedRoles) => {

--- a/src/app/users/newUserDetails.js
+++ b/src/app/users/newUserDetails.js
@@ -127,10 +127,10 @@ const post = async (req, res) => {
   if (model.isDSIUser) {
     req.session.user.uid = model.uid;
     return req.query.review
-      ? res.redirect(`/approvals/${req.params.orgId}/users/${req.session.user.uid}/confirm-user?review=true`)
-      : res.redirect(`/approvals/${req.params.orgId}/users/${req.session.user.uid}/confirm-user`);
+      ? res.sessionRedirect(`/approvals/${req.params.orgId}/users/${req.session.user.uid}/confirm-user?review=true`)
+      : res.sessionRedirect(`/approvals/${req.params.orgId}/users/${req.session.user.uid}/confirm-user`);
   } else {
-    return req.query.review ? res.redirect('confirm-new-user') : res.redirect('organisation-permissions');
+    return req.query.review ? res.sessionRedirect('confirm-new-user') : res.sessionRedirect('organisation-permissions');
   }
 };
 

--- a/src/app/users/organisationPermission.js
+++ b/src/app/users/organisationPermission.js
@@ -68,7 +68,7 @@ const post = async (req, res) => {
   }
   req.session.user.permission = model.selectedLevel;
   const redirectLink = buildRedirectLink(req);
-  return res.redirect(redirectLink);
+  return res.sessionRedirect(redirectLink);
 };
 
 module.exports = {

--- a/src/app/users/selectOrganisation.js
+++ b/src/app/users/selectOrganisation.js
@@ -35,7 +35,7 @@ const handleRedirectAfterOrgSelected = (req, res, model, isApprover, isManage) =
 
   if (isAddService(req) || isRequestService(req)) {
     if (isApproverForSelectedOrg) {
-      return res.redirect(`/approvals/${model.selectedOrganisation}/users/${req.user.sub}/associate-services`);
+      return res.sessionRedirect(`/approvals/${model.selectedOrganisation}/users/${req.user.sub}/associate-services`);
     }
 
     if (isApprover && !isManage) {
@@ -47,11 +47,11 @@ const handleRedirectAfterOrgSelected = (req, res, model, isApprover, isManage) =
         `Because you are not an approver at this organisation, you will need to request access to a service in order to use it. This request will be sent to approvers at <b>${selectedOrg[0].organisation.name}</b>.`,
       );
     }
-    return res.redirect(`/request-service/${model.selectedOrganisation}/users/${req.user.sub}`);
+    return res.sessionRedirect(`/request-service/${model.selectedOrganisation}/users/${req.user.sub}`);
   } else if (isOrganisationInvite(req)) {
-    return res.redirect(`/approvals/${model.selectedOrganisation}/users/new-user`);
+    return res.sessionRedirect(`/approvals/${model.selectedOrganisation}/users/new-user`);
   } else if (isViewOrganisationRequests(req)) {
-    return res.redirect(`/access-requests/${model.selectedOrganisation}/requests`);
+    return res.sessionRedirect(`/access-requests/${model.selectedOrganisation}/requests`);
   } else {
     return res.redirect(`/approvals/users`);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -151,8 +151,8 @@ const init = async () => {
     session({
       name: 'session',
       store: redisStore,
-      resave: true,
-      saveUninitialized: true,
+      resave: false,
+      saveUninitialized: false,
       secret: config.hostingEnvironment.sessionSecret,
       maxAge: expiryInMinutes * 60000, // Expiry in milliseconds
       cookie: {

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const path = require('path');
 const csurf = require('csurf');
 const flash = require('login.dfe.express-flash-2');
 const getPassportStrategy = require('./infrastructure/oidc');
-const { setUserContext, asyncMiddleware, setConfigContext } = require('./infrastructure/utils');
+const { setUserContext, asyncMiddleware, setConfigContext, addSessionRedirect } = require('./infrastructure/utils');
 const helmet = require('helmet');
 const sanitization = require('login.dfe.sanitization');
 const { getErrorHandler, ejsErrorPages } = require('login.dfe.express-error-handling');
@@ -163,6 +163,7 @@ const init = async () => {
     }),
   );
 
+  app.use(addSessionRedirect);
   app.use((req, res, next) => {
     req.session.now = Date.now();
     next();

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const path = require('path');
 const csurf = require('csurf');
 const flash = require('login.dfe.express-flash-2');
 const getPassportStrategy = require('./infrastructure/oidc');
-const { setUserContext, asyncMiddleware, setConfigContext, addSessionRedirect } = require('./infrastructure/utils');
+const { setUserContext, setConfigContext, addSessionRedirect } = require('./infrastructure/utils');
 const helmet = require('helmet');
 const sanitization = require('login.dfe.sanitization');
 const { getErrorHandler, ejsErrorPages } = require('login.dfe.express-error-handling');
@@ -212,8 +212,7 @@ const init = async () => {
 
   const errorPageRenderer = ejsErrorPages.getErrorPageRenderer(
     {
-      help: config.hostingEnvironment.helpUrl,
-      assets: assetsUrl,
+      ...app.locals.urls,
       assetsVersion: config.assets.version,
     },
     config.hostingEnvironment.env === 'dev',

--- a/src/index.js
+++ b/src/index.js
@@ -163,7 +163,6 @@ const init = async () => {
     }),
   );
 
-  app.use(addSessionRedirect);
   app.use((req, res, next) => {
     req.session.now = Date.now();
     next();
@@ -208,8 +207,6 @@ const init = async () => {
   app.use(setUserContext);
   app.use(setConfigContext);
 
-  registerRoutes(app, csrf);
-
   const errorPageRenderer = ejsErrorPages.getErrorPageRenderer(
     {
       ...app.locals.urls,
@@ -217,6 +214,11 @@ const init = async () => {
     },
     config.hostingEnvironment.env === 'dev',
   );
+
+  app.use(addSessionRedirect(errorPageRenderer, logger));
+
+  registerRoutes(app, csrf);
+
   app.use(
     getErrorHandler({
       logger,

--- a/src/infrastructure/utils/index.js
+++ b/src/infrastructure/utils/index.js
@@ -18,6 +18,20 @@ const isLoggedIn = (req, res, next) => {
   return res.status(302).redirect('/auth');
 };
 
+const addSessionRedirect = (req, res, next) => {
+  res.sessionRedirect = (redirectLocation) => {
+    req.session.save((error) => {
+      if (error) {
+        throw new Error(`Error saving session for request ${req.method} ${req.originalUrl}: ${error}`);
+      } else {
+        res.redirect(redirectLocation);
+      }
+    });
+  };
+
+  return next();
+};
+
 const isApprover = (req, res, next) => {
   if (req.userOrganisations) {
     const userApproverOrgs = req.userOrganisations.filter((x) => x.role.id === 10000);
@@ -105,6 +119,7 @@ const mapRole = (roleId) => {
 
 module.exports = {
   isLoggedIn,
+  addSessionRedirect,
   getUserEmail,
   getUserDisplayName,
   setUserContext,

--- a/src/infrastructure/utils/index.js
+++ b/src/infrastructure/utils/index.js
@@ -35,7 +35,13 @@ const addSessionRedirect = (errorPageRenderer, logger = console) => {
         if (error) {
           const initialError = error instanceof Error ? error.message : error;
           const errorMessage = `Error saving session for request ${req.method} ${req.originalUrl}: ${initialError}`;
-          logger.error(errorMessage);
+          logger.error(errorMessage, {
+            correlationId: req.id,
+            stack:
+              error instanceof Error
+                ? (error.stack ?? 'No stack trace provided on Error object')
+                : 'No stack trace available as error is not an Error instance',
+          });
           const { content, contentType } = errorPageRenderer(errorMessage);
           return res.status(500).contentType(contentType).send(content);
         } else {

--- a/src/infrastructure/utils/index.js
+++ b/src/infrastructure/utils/index.js
@@ -1,13 +1,11 @@
 'use strict';
 
 const config = require('./../config');
-const { getServicesForUser } = require('../../infrastructure/access');
 const {
   getOrganisationAndServiceForUserV2,
   getAllRequestsForApprover,
   getAllRequestsTypesForApprover,
 } = require('./../organisations');
-const APPROVER = 10000;
 
 const isLoggedIn = (req, res, next) => {
   if (req.isAuthenticated() || req.originalUrl.startsWith('/signout?redirected=true')) {
@@ -18,18 +16,36 @@ const isLoggedIn = (req, res, next) => {
   return res.status(302).redirect('/auth');
 };
 
-const addSessionRedirect = (req, res, next) => {
-  res.sessionRedirect = (redirectLocation) => {
-    req.session.save((error) => {
-      if (error) {
-        throw new Error(`Error saving session for request ${req.method} ${req.originalUrl}: ${error}`);
-      } else {
-        res.redirect(redirectLocation);
-      }
-    });
-  };
+const addSessionRedirect = (errorPageRenderer, logger = console) => {
+  if (typeof errorPageRenderer !== 'function') {
+    throw new Error('addSessionRedirect errorPageRenderer must be a function');
+  }
 
-  return next();
+  if (typeof logger.error !== 'function') {
+    throw new Error('addSessionRedirect logger must have an error method');
+  }
+
+  return (req, res, next) => {
+    res.sessionRedirect = (redirectLocation) => {
+      if (typeof redirectLocation !== 'string') {
+        throw new Error('sessionRedirect redirect location must be a string');
+      }
+
+      req.session.save((error) => {
+        if (error) {
+          const initialError = error instanceof Error ? error.message : error;
+          const errorMessage = `Error saving session for request ${req.method} ${req.originalUrl}: ${initialError}`;
+          logger.error(errorMessage);
+          const { content, contentType } = errorPageRenderer(errorMessage);
+          return res.status(500).contentType(contentType).send(content);
+        } else {
+          res.redirect(redirectLocation);
+        }
+      });
+    };
+
+    return next();
+  };
 };
 
 const isApprover = (req, res, next) => {

--- a/test/unit/app/requestOrganisation/review.post.test.js
+++ b/test/unit/app/requestOrganisation/review.post.test.js
@@ -254,7 +254,7 @@ describe('when reviewing an organisation request', () => {
   it('then it should redirect to organisations', async () => {
     await post(req, res);
 
-    expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe(`/organisations`);
+    expect(res.sessionRedirect.mock.calls).toHaveLength(1);
+    expect(res.sessionRedirect.mock.calls[0][0]).toBe(`/organisations`);
   });
 });

--- a/test/unit/app/requestOrganisation/selectOrganisation.post.test.js
+++ b/test/unit/app/requestOrganisation/selectOrganisation.post.test.js
@@ -114,8 +114,8 @@ describe('when showing the searching for a organisation', () => {
 
     await post(req, res);
 
-    expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe('review');
+    expect(res.sessionRedirect.mock.calls).toHaveLength(1);
+    expect(res.sessionRedirect.mock.calls[0][0]).toBe('review');
     expect(res.render.mock.calls).toHaveLength(0);
   });
 

--- a/test/unit/app/requestService/confirmServiceRequest.get.test.js
+++ b/test/unit/app/requestService/confirmServiceRequest.get.test.js
@@ -1,0 +1,52 @@
+jest.mock('./../../../../src/infrastructure/access');
+jest.mock('./../../../../src/infrastructure/config', () => require('./../../../utils/jestMocks').mockConfig());
+jest.mock('./../../../../src/infrastructure/logger', () => require('./../../../utils/jestMocks').mockLogger());
+jest.mock('./../../../../src/infrastructure/helpers/allServicesAppCache');
+jest.mock('login.dfe.dao', () => require('../../../utils/jestMocks').mockDao());
+jest.mock('./../../../../src/app/requestService/utils');
+jest.mock('uuid');
+jest.mock('login.dfe.notifications.client');
+
+const { mockRequest, mockResponse } = require('./../../../utils/jestMocks');
+const logger = require('./../../../../src/infrastructure/logger');
+const getConfirmServiceRequest = require('./../../../../src/app/requestService/confirmServiceRequest').get;
+
+describe('when viewing the service request confirmation', () => {
+  let req;
+  const res = mockResponse();
+
+  beforeEach(() => {
+    req = mockRequest({
+      session: {
+        user: {},
+      },
+    });
+    res.mockResetAll();
+  });
+
+  it('then it should redirect the user to /my-services and log a warning message if user services do not exist in the session', async () => {
+    req.session.user.services = undefined;
+    req.originalUrl = 'test/foo';
+    await getConfirmServiceRequest(req, res);
+
+    expect(res.redirect).toHaveBeenCalledTimes(1);
+    expect(res.redirect).toHaveBeenCalledWith('/my-services');
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      `GET ${req.originalUrl} missing user session services, redirecting to my-services`,
+    );
+  });
+
+  it('then it should redirect the user to /my-services and log a warning message if user services are empty in the session', async () => {
+    req.session.user.services = [];
+    req.originalUrl = 'test/foo';
+    await getConfirmServiceRequest(req, res);
+
+    expect(res.redirect).toHaveBeenCalledTimes(1);
+    expect(res.redirect).toHaveBeenCalledWith('/my-services');
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      `GET ${req.originalUrl} missing user session services, redirecting to my-services`,
+    );
+  });
+});

--- a/test/unit/app/requestService/confirmServiceRequest.post.test.js
+++ b/test/unit/app/requestService/confirmServiceRequest.post.test.js
@@ -1,0 +1,52 @@
+jest.mock('./../../../../src/infrastructure/access');
+jest.mock('./../../../../src/infrastructure/config', () => require('./../../../utils/jestMocks').mockConfig());
+jest.mock('./../../../../src/infrastructure/logger', () => require('./../../../utils/jestMocks').mockLogger());
+jest.mock('./../../../../src/infrastructure/helpers/allServicesAppCache');
+jest.mock('login.dfe.dao', () => require('../../../utils/jestMocks').mockDao());
+jest.mock('../../../../src/app/requestService/utils');
+jest.mock('uuid');
+jest.mock('login.dfe.notifications.client');
+
+const { mockRequest, mockResponse } = require('./../../../utils/jestMocks');
+const logger = require('./../../../../src/infrastructure/logger');
+const postConfirmServiceRequest = require('./../../../../src/app/requestService/confirmServiceRequest').post;
+
+describe('when viewing the service request confirmation', () => {
+  let req;
+  const res = mockResponse();
+
+  beforeEach(() => {
+    req = mockRequest({
+      session: {
+        user: {},
+      },
+    });
+    res.mockResetAll();
+  });
+
+  it('then it should redirect the user to /my-services and log a warning message if user services do not exist in the session', async () => {
+    req.session.user.services = undefined;
+    req.originalUrl = 'test/foo';
+    await postConfirmServiceRequest(req, res);
+
+    expect(res.redirect).toHaveBeenCalledTimes(1);
+    expect(res.redirect).toHaveBeenCalledWith('/my-services');
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      `POST ${req.originalUrl} missing user session services, redirecting to my-services`,
+    );
+  });
+
+  it('then it should redirect the user to /my-services and log a warning message if user services are empty in the session', async () => {
+    req.session.user.services = [];
+    req.originalUrl = 'test/foo';
+    await postConfirmServiceRequest(req, res);
+
+    expect(res.redirect).toHaveBeenCalledTimes(1);
+    expect(res.redirect).toHaveBeenCalledWith('/my-services');
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      `POST ${req.originalUrl} missing user session services, redirecting to my-services`,
+    );
+  });
+});

--- a/test/unit/app/requestService/requestEditRoles.post.test.js
+++ b/test/unit/app/requestService/requestEditRoles.post.test.js
@@ -133,7 +133,7 @@ describe('when displaying the request edit service view', () => {
   it('then it should redirect to confirmEditRolesRequest page if selection meet requirements of service', async () => {
     await postRequestEditRoles(req, res);
 
-    expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe(`service1/confirm-edit-roles-request`);
+    expect(res.sessionRedirect.mock.calls).toHaveLength(1);
+    expect(res.sessionRedirect.mock.calls[0][0]).toBe(`service1/confirm-edit-roles-request`);
   });
 });

--- a/test/unit/app/requestService/requestRoles.post.test.js
+++ b/test/unit/app/requestService/requestRoles.post.test.js
@@ -1,0 +1,48 @@
+jest.mock('login.dfe.policy-engine');
+jest.mock('./../../../../src/infrastructure/config', () => require('./../../../utils/jestMocks').mockConfig());
+jest.mock('./../../../../src/infrastructure/logger', () => require('./../../../utils/jestMocks').mockLogger());
+jest.mock('./../../../../src/infrastructure/applications');
+
+const { mockRequest, mockResponse } = require('./../../../utils/jestMocks');
+const logger = require('./../../../../src/infrastructure/logger');
+const postRequestRoles = require('./../../../../src/app/requestService/requestRoles').post;
+
+describe('when submitting the chosen sub-services', () => {
+  let req;
+  const res = mockResponse();
+
+  beforeEach(() => {
+    req = mockRequest({
+      session: {
+        user: {},
+      },
+    });
+    res.mockResetAll();
+  });
+
+  it('then it should redirect the user to /my-services and log a warning message if user services do not exist in the session', async () => {
+    req.session.user.services = undefined;
+    req.originalUrl = 'test/foo';
+    await postRequestRoles(req, res);
+
+    expect(res.redirect).toHaveBeenCalledTimes(1);
+    expect(res.redirect).toHaveBeenCalledWith('/my-services');
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      `POST ${req.originalUrl} missing user session services, redirecting to my-services`,
+    );
+  });
+
+  it('then it should redirect the user to /my-services and log a warning message if user services are empty in the session', async () => {
+    req.session.user.services = [];
+    req.originalUrl = 'test/foo';
+    await postRequestRoles(req, res);
+
+    expect(res.redirect).toHaveBeenCalledTimes(1);
+    expect(res.redirect).toHaveBeenCalledWith('/my-services');
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      `POST ${req.originalUrl} missing user session services, redirecting to my-services`,
+    );
+  });
+});

--- a/test/unit/app/users/postAssociateRoles.test.js
+++ b/test/unit/app/users/postAssociateRoles.test.js
@@ -88,8 +88,8 @@ describe('when selecting the roles for a service', () => {
   it('then it should redirect to confirm user page if no more services', async () => {
     await postAssociateRoles(req, res);
 
-    expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe(`/approvals/${req.params.orgId}/users/confirm-new-user`);
+    expect(res.sessionRedirect.mock.calls).toHaveLength(1);
+    expect(res.sessionRedirect.mock.calls[0][0]).toBe(`/approvals/${req.params.orgId}/users/confirm-new-user`);
   });
 
   it('then it should transform selected roles in an array', async () => {
@@ -101,8 +101,8 @@ describe('when selecting the roles for a service', () => {
     await postAssociateRoles(req, res);
 
     const expectedRedirectUrl = `https://${config.hostingEnvironment.host}:${config.hostingEnvironment.port}/request-service/org1/users/user1/services/service1/roles/%5B%22selected-role-id%22%5D/sub-service-req-id-1/approve-roles-request`;
-    expect(res.redirect).toHaveBeenCalledTimes(1);
-    expect(res.redirect).toHaveBeenCalledWith(expectedRedirectUrl);
+    expect(res.sessionRedirect).toHaveBeenCalledTimes(1);
+    expect(res.sessionRedirect).toHaveBeenCalledWith(expectedRedirectUrl);
   });
 
   it('then it should get the users organisations if the user is active', async () => {
@@ -179,8 +179,8 @@ describe('when selecting the roles for a service', () => {
     req.session.user.uid = 'user1';
     await postAssociateRoles(req, res);
 
-    expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe(
+    expect(res.sessionRedirect.mock.calls).toHaveLength(1);
+    expect(res.sessionRedirect.mock.calls[0][0]).toBe(
       `/approvals/${req.params.orgId}/users/${req.session.user.uid}/confirm-details`,
     );
   });
@@ -200,8 +200,8 @@ describe('when selecting the roles for a service', () => {
     await postAssociateRoles(req, res);
 
     const expectedRedirectUrl = `https://${config.hostingEnvironment.host}:${config.hostingEnvironment.port}/access-requests/service-requests/service-req-id/services/service1/roles/role1`;
-    expect(res.redirect).toHaveBeenCalledTimes(1);
-    expect(res.redirect).toHaveBeenCalledWith(expectedRedirectUrl);
+    expect(res.sessionRedirect).toHaveBeenCalledTimes(1);
+    expect(res.sessionRedirect).toHaveBeenCalledWith(expectedRedirectUrl);
   });
 
   it('then it should redirect to "Review request" page when changing the service in a service request', async () => {
@@ -219,8 +219,8 @@ describe('when selecting the roles for a service', () => {
     await postAssociateRoles(req, res);
 
     const expectedRedirectUrl = `https://${config.hostingEnvironment.host}:${config.hostingEnvironment.port}/access-requests/service-requests/service-req-id/services/service1/roles/role1`;
-    expect(res.redirect).toHaveBeenCalledTimes(1);
-    expect(res.redirect).toHaveBeenCalledWith(expectedRedirectUrl);
+    expect(res.sessionRedirect).toHaveBeenCalledTimes(1);
+    expect(res.sessionRedirect).toHaveBeenCalledWith(expectedRedirectUrl);
   });
 
   it('then it should redirect to "Review request" page when changing the sub-service in a service request with correct path if no role selected', async () => {
@@ -238,8 +238,8 @@ describe('when selecting the roles for a service', () => {
     await postAssociateRoles(req, res);
 
     const expectedRedirectUrl = `https://${config.hostingEnvironment.host}:${config.hostingEnvironment.port}/access-requests/service-requests/service-req-id/services/service1/roles/null`;
-    expect(res.redirect).toHaveBeenCalledTimes(1);
-    expect(res.redirect).toHaveBeenCalledWith(expectedRedirectUrl);
+    expect(res.sessionRedirect).toHaveBeenCalledTimes(1);
+    expect(res.sessionRedirect).toHaveBeenCalledWith(expectedRedirectUrl);
   });
 
   it('then it should redirect to "Review request" page when changing the service in a service request with correct path if no role selected', async () => {
@@ -257,8 +257,8 @@ describe('when selecting the roles for a service', () => {
     await postAssociateRoles(req, res);
 
     const expectedRedirectUrl = `https://${config.hostingEnvironment.host}:${config.hostingEnvironment.port}/access-requests/service-requests/service-req-id/services/service1/roles/null`;
-    expect(res.redirect).toHaveBeenCalledTimes(1);
-    expect(res.redirect).toHaveBeenCalledWith(expectedRedirectUrl);
+    expect(res.sessionRedirect).toHaveBeenCalledTimes(1);
+    expect(res.sessionRedirect).toHaveBeenCalledWith(expectedRedirectUrl);
   });
 
   it('then it should redirect to "Review request" page when changing the sub-service in a sub-service request from email journey', async () => {
@@ -269,8 +269,8 @@ describe('when selecting the roles for a service', () => {
     await postAssociateRoles(req, res);
 
     const expectedRedirectUrl = `https://${config.hostingEnvironment.host}:${config.hostingEnvironment.port}/request-service/org1/users/user1/services/service1/roles/%5B%5D/sub-service-req-id-1/approve-roles-request`;
-    expect(res.redirect).toHaveBeenCalledTimes(1);
-    expect(res.redirect).toHaveBeenCalledWith(expectedRedirectUrl);
+    expect(res.sessionRedirect).toHaveBeenCalledTimes(1);
+    expect(res.sessionRedirect).toHaveBeenCalledWith(expectedRedirectUrl);
   });
 
   it('then it should redirect to the next service if one exists', async () => {
@@ -286,8 +286,8 @@ describe('when selecting the roles for a service', () => {
     ];
     await postAssociateRoles(req, res);
 
-    expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe('service2');
+    expect(res.sessionRedirect.mock.calls).toHaveLength(1);
+    expect(res.sessionRedirect.mock.calls[0][0]).toBe('service2');
   });
 
   it('then it should redirect to users list if no user in session', async () => {

--- a/test/unit/app/users/postAssociateServices.test.js
+++ b/test/unit/app/users/postAssociateServices.test.js
@@ -305,7 +305,7 @@ describe('when adding services to a user', () => {
     req.body.service = ['service1'];
     await postAssociateServices(req, res);
 
-    expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe(`associate-services/${req.session.user.services[0].serviceId}`);
+    expect(res.sessionRedirect.mock.calls).toHaveLength(1);
+    expect(res.sessionRedirect.mock.calls[0][0]).toBe(`associate-services/${req.session.user.services[0].serviceId}`);
   });
 });

--- a/test/unit/app/users/postNewUserDetails.test.js
+++ b/test/unit/app/users/postNewUserDetails.test.js
@@ -224,8 +224,8 @@ describe('when entering a new users details', () => {
     process.env.emailValidation = 'false';
     await postNewUserDetails(req, res);
 
-    expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe('organisation-permissions');
+    expect(res.sessionRedirect.mock.calls).toHaveLength(1);
+    expect(res.sessionRedirect.mock.calls[0][0]).toBe('organisation-permissions');
   });
 
   it('then it should render view if email already associated to a user in this org', async () => {
@@ -323,8 +323,8 @@ describe('when entering a new users details', () => {
 
     await postNewUserDetails(req, res);
 
-    expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe(
+    expect(res.sessionRedirect.mock.calls).toHaveLength(1);
+    expect(res.sessionRedirect.mock.calls[0][0]).toBe(
       `/approvals/${req.params.orgId}/users/${req.session.user.uid}/confirm-user`,
     );
   });
@@ -344,8 +344,8 @@ describe('when entering a new users details', () => {
 
     await postNewUserDetails(req, res);
 
-    expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe(
+    expect(res.sessionRedirect.mock.calls).toHaveLength(1);
+    expect(res.sessionRedirect.mock.calls[0][0]).toBe(
       `/approvals/${req.params.orgId}/users/${req.session.user.uid}/confirm-user`,
     );
   });
@@ -373,8 +373,8 @@ describe('when entering a new users details', () => {
 
     await postNewUserDetails(req, res);
 
-    expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe(
+    expect(res.sessionRedirect.mock.calls).toHaveLength(1);
+    expect(res.sessionRedirect.mock.calls[0][0]).toBe(
       `/approvals/${req.params.orgId}/users/${req.session.user.uid}/confirm-user?review=true`,
     );
   });

--- a/test/unit/app/users/postOrganisationPermission.test.js
+++ b/test/unit/app/users/postOrganisationPermission.test.js
@@ -94,15 +94,15 @@ describe('when select the organisation permission level', () => {
 
   it('then it should redirect to the associate-services page if the selection is not reviewed and it is valid', async () => {
     await postOrganisationPermission(req, res);
-    expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe(`associate-services`);
+    expect(res.sessionRedirect.mock.calls).toHaveLength(1);
+    expect(res.sessionRedirect.mock.calls[0][0]).toBe(`associate-services`);
   });
 
   it('then it should redirect to the confirm new user page if the selection is reviewed and it is valid', async () => {
     req.query.review = 'true';
 
     await postOrganisationPermission(req, res);
-    expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe(`confirm-new-user`);
+    expect(res.sessionRedirect.mock.calls).toHaveLength(1);
+    expect(res.sessionRedirect.mock.calls[0][0]).toBe(`confirm-new-user`);
   });
 });

--- a/test/unit/infrastructure/utils/addSessionRedirect.test.js
+++ b/test/unit/infrastructure/utils/addSessionRedirect.test.js
@@ -2,9 +2,10 @@ const { mockConfig, mockRequest, mockResponse } = require('../../../utils/jestMo
 
 jest.mock('../../../../src/infrastructure/config', () => mockConfig());
 
-let req;
+let req, consoleMock;
 const res = mockResponse();
 const { addSessionRedirect } = require('../../../../src/infrastructure/utils');
+const errorPageRenderer = jest.fn();
 
 describe('When using the addSessionRedirect middleware', () => {
   beforeEach(() => {
@@ -14,32 +15,74 @@ describe('When using the addSessionRedirect middleware', () => {
       },
     });
     res.mockResetAll();
+
+    consoleMock = jest.spyOn(console, 'error').mockImplementation();
+    errorPageRenderer.mockImplementation(() => ({
+      content: 'test',
+      contentType: 'html',
+    }));
   });
 
   afterEach(() => {
     res.sessionRedirect = jest.fn();
+    consoleMock.mockRestore();
+  });
+
+  describe('The middleware builder', () => {
+    it.each([123, {}, [], null, undefined, false, 'test'])(
+      'Throws an error if errorPageRenderer is not a function (%p)',
+      (value) => {
+        expect(() => addSessionRedirect(value)).toThrow('addSessionRedirect errorPageRenderer must be a function');
+      },
+    );
+
+    it('Does not throw an error if errorPageRenderer is a function', () => {
+      expect(() => addSessionRedirect(() => {})).not.toThrow();
+    });
+
+    it('Throws an error if logger does not have an error method', () => {
+      expect(() => addSessionRedirect(errorPageRenderer, { warn: () => {} })).toThrow(
+        'addSessionRedirect logger must have an error method',
+      );
+    });
+
+    it('Does not throw an error if logger has an error method', () => {
+      expect(() => addSessionRedirect(errorPageRenderer, { error: () => {} })).not.toThrow();
+    });
+
+    it('Returns the middleware function', () => {
+      expect(typeof addSessionRedirect(errorPageRenderer)).toBe('function');
+    });
   });
 
   describe('The middleware function', () => {
     it('Adds the sessionRedirect method to the response object', () => {
       res.sessionRedirect = null;
-      addSessionRedirect(req, res, () => {});
+      addSessionRedirect(errorPageRenderer)(req, res, () => {});
 
       expect(typeof res.sessionRedirect).toBe('function');
     });
 
     it('Returns the result of the 3rd argument (next) to match express middleware functionality', () => {
-      const result = addSessionRedirect(req, res, () => 42);
+      const result = addSessionRedirect(errorPageRenderer)(req, res, () => 42);
       expect(result).toBe(42);
     });
   });
 
   describe('The sessionRedirect response method', () => {
+    it.each([123, {}, [], null, undefined, false])(
+      'Should throw an error if the redirect location is not a string (%p)',
+      (value) => {
+        addSessionRedirect(errorPageRenderer)(req, res, () => {});
+        expect(() => res.sessionRedirect(value)).toThrow('sessionRedirect redirect location must be a string');
+      },
+    );
+
     it.each([false, undefined, null, '', 0])(
       'Should redirect if req.session.save returns a falsy value (%p)',
       (value) => {
         req.session.save.mockImplementation((callback) => callback(value));
-        addSessionRedirect(req, res, () => {});
+        addSessionRedirect(errorPageRenderer)(req, res, () => {});
 
         res.sessionRedirect('/test');
         expect(res.redirect).toHaveBeenCalledTimes(1);
@@ -48,17 +91,56 @@ describe('When using the addSessionRedirect middleware', () => {
     );
 
     it.each([true, {}, [], 'test', 42])(
-      'Should throw an appropriate error if req.session.save returns a truthy value (%p)',
+      'Should log the string representation of error if req.session.save returns a truthy value (%p)',
       (value) => {
         req.session.save.mockImplementation((callback) => callback(value));
         req.method = 'POST';
         req.originalUrl = '/testing/test/foo';
-        addSessionRedirect(req, res, () => {});
+        addSessionRedirect(errorPageRenderer)(req, res, () => {});
 
-        expect(() => res.sessionRedirect('/test')).toThrow(
+        res.sessionRedirect('/test');
+        expect(consoleMock).toHaveBeenCalledTimes(1);
+        expect(consoleMock).toHaveBeenCalledWith(
           `Error saving session for request ${req.method} ${req.originalUrl}: ${value}`,
         );
       },
     );
+
+    it("Should log the error's message property if req.session.save returns an instance of Error", () => {
+      const error = new Error('test error');
+      req.session.save.mockImplementation((callback) => callback(error));
+      req.method = 'POST';
+      req.originalUrl = '/testing/test/foo';
+      addSessionRedirect(errorPageRenderer)(req, res, () => {});
+
+      res.sessionRedirect('/test');
+      expect(consoleMock).toHaveBeenCalledTimes(1);
+      expect(consoleMock).toHaveBeenCalledWith(
+        `Error saving session for request ${req.method} ${req.originalUrl}: ${error.message}`,
+      );
+    });
+
+    it('Should send an error response to the user if req.session.save returns a truthy value', () => {
+      req.session.save.mockImplementation((callback) => callback(new Error('')));
+      req.method = 'POST';
+      req.originalUrl = '/testing/test/foo';
+      errorPageRenderer.mockImplementation(() => ({
+        content: 'test',
+        contentType: 'html',
+      }));
+      addSessionRedirect(errorPageRenderer)(req, res, () => {});
+
+      res.sessionRedirect('/test');
+      expect(errorPageRenderer).toHaveBeenCalledTimes(1);
+      expect(errorPageRenderer).toHaveBeenCalledWith(
+        `Error saving session for request ${req.method} ${req.originalUrl}: `,
+      );
+      expect(res.status).toHaveBeenCalledTimes(1);
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.contentType).toHaveBeenCalledTimes(1);
+      expect(res.contentType).toHaveBeenCalledWith('html');
+      expect(res.send).toHaveBeenCalledTimes(1);
+      expect(res.send).toHaveBeenCalledWith('test');
+    });
   });
 });

--- a/test/unit/infrastructure/utils/addSessionRedirect.test.js
+++ b/test/unit/infrastructure/utils/addSessionRedirect.test.js
@@ -1,0 +1,64 @@
+const { mockConfig, mockRequest, mockResponse } = require('../../../utils/jestMocks');
+
+jest.mock('../../../../src/infrastructure/config', () => mockConfig());
+
+let req;
+const res = mockResponse();
+const { addSessionRedirect } = require('../../../../src/infrastructure/utils');
+
+describe('When using the addSessionRedirect middleware', () => {
+  beforeEach(() => {
+    req = mockRequest({
+      session: {
+        save: jest.fn(),
+      },
+    });
+    res.mockResetAll();
+  });
+
+  afterEach(() => {
+    res.sessionRedirect = jest.fn();
+  });
+
+  describe('The middleware function', () => {
+    it('Adds the sessionRedirect method to the response object', () => {
+      res.sessionRedirect = null;
+      addSessionRedirect(req, res, () => {});
+
+      expect(typeof res.sessionRedirect).toBe('function');
+    });
+
+    it('Returns the result of the 3rd argument (next) to match express middleware functionality', () => {
+      const result = addSessionRedirect(req, res, () => 42);
+      expect(result).toBe(42);
+    });
+  });
+
+  describe('The sessionRedirect response method', () => {
+    it.each([false, undefined, null, '', 0])(
+      'Should redirect if req.session.save returns a falsy value (%p)',
+      (value) => {
+        req.session.save.mockImplementation((callback) => callback(value));
+        addSessionRedirect(req, res, () => {});
+
+        res.sessionRedirect('/test');
+        expect(res.redirect).toHaveBeenCalledTimes(1);
+        expect(res.redirect).toHaveBeenCalledWith('/test');
+      },
+    );
+
+    it.each([true, {}, [], 'test', 42])(
+      'Should throw an appropriate error if req.session.save returns a truthy value (%p)',
+      (value) => {
+        req.session.save.mockImplementation((callback) => callback(value));
+        req.method = 'POST';
+        req.originalUrl = '/testing/test/foo';
+        addSessionRedirect(req, res, () => {});
+
+        expect(() => res.sessionRedirect('/test')).toThrow(
+          `Error saving session for request ${req.method} ${req.originalUrl}: ${value}`,
+        );
+      },
+    );
+  });
+});

--- a/test/utils/jestMocks.js
+++ b/test/utils/jestMocks.js
@@ -147,10 +147,12 @@ const mockResponse = () => {
   return {
     render: jest.fn(),
     redirect: jest.fn(),
+    sessionRedirect: jest.fn(),
     flash: jest.fn(),
     mockResetAll: function () {
       this.render.mockReset().mockReturnValue(this);
       this.redirect.mockReset().mockReturnValue(this);
+      this.sessionRedirect.mockReset().mockReturnValue(this);
       this.flash.mockReset().mockReturnValue(this);
     },
   };

--- a/test/utils/jestMocks.js
+++ b/test/utils/jestMocks.js
@@ -145,15 +145,21 @@ const mockRequest = (customRequest = {}) => {
 };
 const mockResponse = () => {
   return {
-    render: jest.fn(),
-    redirect: jest.fn(),
-    sessionRedirect: jest.fn(),
+    contentType: jest.fn(),
     flash: jest.fn(),
+    redirect: jest.fn(),
+    render: jest.fn(),
+    send: jest.fn(),
+    sessionRedirect: jest.fn(),
+    status: jest.fn(),
     mockResetAll: function () {
-      this.render.mockReset().mockReturnValue(this);
-      this.redirect.mockReset().mockReturnValue(this);
-      this.sessionRedirect.mockReset().mockReturnValue(this);
+      this.contentType.mockReset().mockReturnValue(this);
       this.flash.mockReset().mockReturnValue(this);
+      this.redirect.mockReset().mockReturnValue(this);
+      this.render.mockReset().mockReturnValue(this);
+      this.send.mockReset().mockReturnValue(this);
+      this.sessionRedirect.mockReset().mockReturnValue(this);
+      this.status.mockReset().mockReturnValue(this);
     },
   };
 };


### PR DESCRIPTION
Ticket: https://dfe-secureaccess.atlassian.net/browse/NSA-8595

## Background (See [NSA-8588](https://dfe-secureaccess.atlassian.net/browse/NSA-8588) for more information):
- Users experience an error when requesting a service or adding it to themselves, after choosing a service and getting to the roles page.
- This error is caused by the user’s session not being saved before they’re being redirected to the roles page, so the page is loading without the required information being present.
- This ticket is to address the error by:
  - Updating the `connect-redis` session settings to match the documentation for the library.
  - Creating a way to ensure the session is saved before redirecting wherever the session is altered then redirected (excluding to the "My services" page or the "Manage users" page, as that clears the variables anyway).
  - Adding in additional checks/logging for if a user gets to a page and the session variables are missing, so we can keep track of this happening in the future.

## Changes

- Minor fixes:
  - Ensured all the URLs for other apps and the survey are passed to the error page template, as the survey link was there but didn't go anywhere as the URL was empty.
  - Removed the `babel-eslint` package, as this was causing ESLint to not function correctly, and according to [the docs](https://github.com/babel/babel-eslint/blob/master/README.md#:~:text=Note%3A%20You%20only%20need%20to%20use%20babel%2Deslint%20if%20you%20are%20using%20Babel%20to%20transform%20your%20code.%20If%20this%20is%20not%20the%20case%2C%20please%20use%20the%20relevant%20parser%20for%20your%20chosen%20flavor%20of%20ECMAScript%20(note%20that%20the%20default%20parser%20supports%20all%20non%2Dexperimental%20syntax%20as%20well%20as%20JSX).) it's only required if we use babel which we are not in this application.
- Updated the `express-session` `resave` and `saveUninitialized` settings to `false`, as we use the `connect-redis` store which specifies setting them both to `false` in [their documentation](https://github.com/tj/connect-redis/blob/2f1ce8f9381e2210e87712a5cc764ed527eb3b3e/readme.md#api).
  - This has been regression tested in TEST to ensure it does not interfere or cause any issues with Entra, and it passed successfully 👍 
- Adds a `sessionRedirect(location)` method to the response object via middleware to act as a drop-in replacement for `res.redirect` and provides the session saving functionality, with the following logical flow:
  - `req.session.save` is called, which takes a callback and will save the session in the session store (Redis) before executing the callback function, and if there are any errors the error will be passed.
  - If there are no errors saving the session then the callback will redirect the user to their specified location.
  - If there is an error, then the following takes place:
    - An error message is generated from the error given in the callback if it's an instance of `Error` then the message is retrieved, otherwise it's the value of the error.
    - This error is logged with the logging library passed in when the middleware is created, which for our application is the normal `winston` logger.
    - An error page is rendered with the errorPageRenderer from `login.dfe.express-error-handling` which displays the "There has been an error" page in exactly the same way as other errors, and with a 500 status code.
- For any routes I could find that set session variables before redirecting, I replaced any redirects that weren't to `my-services` or `/approvals/users` on their own, as these clear `session.user`, with `res.sessionRedirect`.
- For any routes I could find which needed session variables to be present or they'd throw an error, in this ticket it was just for `req.session.user.services` to avoid scope creep, I added a check for whether the variable was an array with 1 or more values present, and if not it will log a warning and redirect to the same page they already redirected to if `req.session.user` wasn't present.
- Unit tests for the above functionality:
  - Ensuring that `res.sessionRedirect` is called instead of `res.redirect` where needed.
  - Ensuring the middleware builder functions correctly, that the middleware itself conforms to Express standards, and `res.sessionRedirect` works as expected.
  - Ensuring that the safeguard redirect if `req.session.user.services` is not an array with 1 or more services is present functions correctly in the routes it was added to.

## Manual Testing

I have run through all the routes in the initial ticket that were causing errors or have been modified by these changes, both with and without injecting an arbitrary timeout of 10secs of the Redis session saving, and all functions correctly. I initially threw the error in `res.sessionRedirect` that was passed but testing of that revealed it was an uncaught exception so users would've been stuck loading until FrontDoor killed the request, which led to the rendering of the error page.

## Reasoning

### Why middleware?

Middleware made more sense to me than a utility function with the same functionality. The main reason is it enables the method to be added to the response application-wide so it can be a drop-in replacement to `res.redirect` wherever it's needed without importing a function. If it was a utility function it would need to take in the request and response objects, which is practically the same signature as middleware anyway. This one's personal preference really, I think the ease of use and the drop-in replacement nature outweighs any downsides I could see, and there was no standard I could find on this when looking into my approach.

### Why render an error page instead of redirecting on session save failure?
The error page rendering came from discovering that if an error is thrown within the callback it would never be caught, and the user would be stuck in a long-running request until FrontDoor killed it (this took me a while to diagnose 😅). I began to implement a failure redirect URL that could be passed in, but if on failure we just redirected to "My services" then the user would just go back to the same page and loop around if there was a failure with Redis or the session being serialized, which would be far more confusing/annoying than a definitive error screen.