### PR TITLE
[NSA-8677] Fix new user from making multiple requests

### DIFF
--- a/src/app/organisations/views/organisations.ejs
+++ b/src/app/organisations/views/organisations.ejs
@@ -19,7 +19,7 @@
 
             <div class="govuk-!-margin-top-9 govuk-!-margin-bottom-9">
                 <% if (locals.flash.title && locals.flash.heading && locals.flash.message) { %>
-                    <div id="notification-wrapper" class="govuk-notification-banner govuk-notification-banner--success"
+                    <div id="notification-wrapper" class="govuk-notification-banner govuk-notification-banner<%= locals.flash.title[0].toLowerCase().includes("success") ? "--success" : "" %>"
                         role="alert" aria-labelledby="govuk-notification-banner-title"
                         data-module="govuk-notification-banner">
                         <div class="govuk-notification-banner__header govuk-grid-row">

--- a/src/app/requestOrganisation/index.js
+++ b/src/app/requestOrganisation/index.js
@@ -1,5 +1,5 @@
 const express = require("express");
-const { isLoggedIn } = require("../../infrastructure/utils");
+const { isLoggedIn, canRequestOrg } = require("../../infrastructure/utils");
 const logger = require("../../infrastructure/logger");
 const { asyncWrapper } = require("login.dfe.express-error-handling");
 
@@ -11,16 +11,13 @@ const router = express.Router({ mergeParams: true });
 const requestOrganisation = (csrf) => {
   logger.info("Mounting request organisation route");
 
-  router.get("/search", isLoggedIn, csrf, asyncWrapper(selectOrganisation.get));
-  router.post(
-    "/search",
-    isLoggedIn,
-    csrf,
-    asyncWrapper(selectOrganisation.post),
-  );
+  router.use(isLoggedIn, canRequestOrg, csrf);
 
-  router.get("/review", isLoggedIn, csrf, asyncWrapper(review.get));
-  router.post("/review", isLoggedIn, csrf, asyncWrapper(review.post));
+  router.get("/search", asyncWrapper(selectOrganisation.get));
+  router.post("/search", asyncWrapper(selectOrganisation.post));
+
+  router.get("/review", asyncWrapper(review.get));
+  router.post("/review", asyncWrapper(review.post));
 
   return router;
 };

--- a/test/unit/infrastructure/utils/canRequestOrg.test.js
+++ b/test/unit/infrastructure/utils/canRequestOrg.test.js
@@ -11,181 +11,75 @@ const {
 } = require("../../../../src/infrastructure/organisations");
 const { canRequestOrg } = require("../../../../src/infrastructure/utils");
 
+function createOrg(id) {
+  return {
+    organisation: {
+      id: `testOrgId${id}`,
+      name: "testOrgName",
+      urn: "testOrgURN",
+      uid: "testOrgUID",
+      upin: "testOrgUPIN",
+      ukprn: "testOrgUKPRN",
+      address: undefined,
+      status: {
+        id: 1,
+        name: "Open",
+      },
+      pimStatus: "1",
+      legacyUserId: undefined,
+      legacyUserName: undefined,
+      category: {
+        id: "002",
+        name: "Local Authority",
+      },
+      type: undefined,
+      providerTypeName: "Local Authority with an Education remit",
+      companyRegistrationNumber: undefined,
+      LegalName: "testOrgLegalName",
+    },
+    role: {
+      id: 0,
+      name: "End user",
+    },
+    approvers: [],
+    services: [],
+    numericIdentifier: undefined,
+    textIdentifier: undefined,
+  };
+}
+
+function createRequest(id) {
+  return {
+    id: `testRequestId${id}`,
+    org_id: "testOrgId",
+    org_name: "testOrgName",
+    LegalName: "testOrgLegalName",
+    urn: "testOrgURN",
+    uid: "testOrgUID",
+    upin: "testOrgUPIN",
+    ukprn: "testOrgUKPRN",
+    org_status: {
+      id: 1,
+      name: "Open",
+    },
+    user_id: "user-1",
+    created_date: Date.now(),
+    status: {
+      id: 0,
+      name: "Pending",
+    },
+  };
+}
+
 describe("When using the canRequestOrg middleware", () => {
   const testUserId = "user-1";
   const res = mockResponse();
   let req;
 
-  const singleOrg = [
-    {
-      organisation: {
-        id: "testOrgId",
-        name: "testOrgName",
-        urn: "testOrgURN",
-        uid: "testOrgUID",
-        upin: "testOrgUPIN",
-        ukprn: "testOrgUKPRN",
-        address: undefined,
-        status: {
-          id: 1,
-          name: "Open",
-        },
-        pimStatus: "1",
-        legacyUserId: undefined,
-        legacyUserName: undefined,
-        category: {
-          id: "002",
-          name: "Local Authority",
-        },
-        type: undefined,
-        providerTypeName: "Local Authority with an Education remit",
-        companyRegistrationNumber: undefined,
-        LegalName: "testOrgLegalName",
-      },
-      role: {
-        id: 0,
-        name: "End user",
-      },
-      approvers: [],
-      services: [],
-      numericIdentifier: undefined,
-      textIdentifier: undefined,
-    },
-  ];
-  const multipleOrgs = [
-    {
-      organisation: {
-        id: "testOrgId",
-        name: "testOrgName",
-        urn: "testOrgURN",
-        uid: "testOrgUID",
-        upin: "testOrgUPIN",
-        ukprn: "testOrgUKPRN",
-        address: undefined,
-        status: {
-          id: 1,
-          name: "Open",
-        },
-        pimStatus: "1",
-        legacyUserId: undefined,
-        legacyUserName: undefined,
-        category: {
-          id: "002",
-          name: "Local Authority",
-        },
-        type: undefined,
-        providerTypeName: "Local Authority with an Education remit",
-        companyRegistrationNumber: undefined,
-        LegalName: "testOrgLegalName",
-      },
-      role: {
-        id: 0,
-        name: "End user",
-      },
-      approvers: [],
-      services: [],
-      numericIdentifier: undefined,
-      textIdentifier: undefined,
-    },
-    {
-      organisation: {
-        id: "testOrgId2",
-        name: "testOrgName",
-        urn: "testOrgURN",
-        uid: "testOrgUID",
-        upin: "testOrgUPIN",
-        ukprn: "testOrgUKPRN",
-        address: undefined,
-        status: {
-          id: 1,
-          name: "Open",
-        },
-        pimStatus: "1",
-        legacyUserId: undefined,
-        legacyUserName: undefined,
-        category: {
-          id: "002",
-          name: "Local Authority",
-        },
-        type: undefined,
-        providerTypeName: "Local Authority with an Education remit",
-        companyRegistrationNumber: undefined,
-        LegalName: "testOrgLegalName",
-      },
-      role: {
-        id: 0,
-        name: "End user",
-      },
-      approvers: [],
-      services: [],
-      numericIdentifier: undefined,
-      textIdentifier: undefined,
-    },
-  ];
-  const singleRequest = [
-    {
-      id: "testRequestId",
-      org_id: "testOrgId",
-      org_name: "testOrgName",
-      LegalName: "testOrgLegalName",
-      urn: "testOrgURN",
-      uid: "testOrgUID",
-      upin: "testOrgUPIN",
-      ukprn: "testOrgUKPRN",
-      org_status: {
-        id: 1,
-        name: "Open",
-      },
-      user_id: testUserId,
-      created_date: Date.now(),
-      status: {
-        id: 0,
-        name: "Pending",
-      },
-    },
-  ];
-  const multipleRequests = [
-    {
-      id: "testRequestId",
-      org_id: "testOrgId",
-      org_name: "testOrgName",
-      LegalName: "testOrgLegalName",
-      urn: "testOrgURN",
-      uid: "testOrgUID",
-      upin: "testOrgUPIN",
-      ukprn: "testOrgUKPRN",
-      org_status: {
-        id: 1,
-        name: "Open",
-      },
-      user_id: testUserId,
-      created_date: Date.now(),
-      status: {
-        id: 0,
-        name: "Pending",
-      },
-    },
-    {
-      id: "testRequestId2",
-      org_id: "testOrgId",
-      org_name: "testOrgName",
-      LegalName: "testOrgLegalName",
-      urn: "testOrgURN",
-      uid: "testOrgUID",
-      upin: "testOrgUPIN",
-      ukprn: "testOrgUKPRN",
-      org_status: {
-        id: 1,
-        name: "Open",
-      },
-      user_id: testUserId,
-      created_date: Date.now(),
-      status: {
-        id: 0,
-        name: "Pending",
-      },
-    },
-  ];
+  const singleOrg = [createOrg(1)];
+  const multipleOrgs = [createOrg(1), createOrg(2)];
+  const singleRequest = [createRequest(1)];
+  const multipleRequests = [createRequest(1), createRequest(2)];
 
   beforeEach(() => {
     req = mockRequest({

--- a/test/unit/infrastructure/utils/canRequestOrg.test.js
+++ b/test/unit/infrastructure/utils/canRequestOrg.test.js
@@ -1,0 +1,318 @@
+jest.mock("../../../../src/infrastructure/config", () => mockConfig());
+jest.mock("../../../../src/infrastructure/organisations");
+
+const {
+  mockConfig,
+  mockRequest,
+  mockResponse,
+} = require("../../../utils/jestMocks");
+const {
+  getPendingRequestsAssociatedWithUser,
+} = require("../../../../src/infrastructure/organisations");
+const { canRequestOrg } = require("../../../../src/infrastructure/utils");
+
+describe("When using the canRequestOrg middleware", () => {
+  const testUserId = "user-1";
+  const res = mockResponse();
+  let req;
+
+  const singleOrg = [
+    {
+      organisation: {
+        id: "testOrgId",
+        name: "testOrgName",
+        urn: "testOrgURN",
+        uid: "testOrgUID",
+        upin: "testOrgUPIN",
+        ukprn: "testOrgUKPRN",
+        address: undefined,
+        status: {
+          id: 1,
+          name: "Open",
+        },
+        pimStatus: "1",
+        legacyUserId: undefined,
+        legacyUserName: undefined,
+        category: {
+          id: "002",
+          name: "Local Authority",
+        },
+        type: undefined,
+        providerTypeName: "Local Authority with an Education remit",
+        companyRegistrationNumber: undefined,
+        LegalName: "testOrgLegalName",
+      },
+      role: {
+        id: 0,
+        name: "End user",
+      },
+      approvers: [],
+      services: [],
+      numericIdentifier: undefined,
+      textIdentifier: undefined,
+    },
+  ];
+  const multipleOrgs = [
+    {
+      organisation: {
+        id: "testOrgId",
+        name: "testOrgName",
+        urn: "testOrgURN",
+        uid: "testOrgUID",
+        upin: "testOrgUPIN",
+        ukprn: "testOrgUKPRN",
+        address: undefined,
+        status: {
+          id: 1,
+          name: "Open",
+        },
+        pimStatus: "1",
+        legacyUserId: undefined,
+        legacyUserName: undefined,
+        category: {
+          id: "002",
+          name: "Local Authority",
+        },
+        type: undefined,
+        providerTypeName: "Local Authority with an Education remit",
+        companyRegistrationNumber: undefined,
+        LegalName: "testOrgLegalName",
+      },
+      role: {
+        id: 0,
+        name: "End user",
+      },
+      approvers: [],
+      services: [],
+      numericIdentifier: undefined,
+      textIdentifier: undefined,
+    },
+    {
+      organisation: {
+        id: "testOrgId2",
+        name: "testOrgName",
+        urn: "testOrgURN",
+        uid: "testOrgUID",
+        upin: "testOrgUPIN",
+        ukprn: "testOrgUKPRN",
+        address: undefined,
+        status: {
+          id: 1,
+          name: "Open",
+        },
+        pimStatus: "1",
+        legacyUserId: undefined,
+        legacyUserName: undefined,
+        category: {
+          id: "002",
+          name: "Local Authority",
+        },
+        type: undefined,
+        providerTypeName: "Local Authority with an Education remit",
+        companyRegistrationNumber: undefined,
+        LegalName: "testOrgLegalName",
+      },
+      role: {
+        id: 0,
+        name: "End user",
+      },
+      approvers: [],
+      services: [],
+      numericIdentifier: undefined,
+      textIdentifier: undefined,
+    },
+  ];
+  const singleRequest = [
+    {
+      id: "testRequestId",
+      org_id: "testOrgId",
+      org_name: "testOrgName",
+      LegalName: "testOrgLegalName",
+      urn: "testOrgURN",
+      uid: "testOrgUID",
+      upin: "testOrgUPIN",
+      ukprn: "testOrgUKPRN",
+      org_status: {
+        id: 1,
+        name: "Open",
+      },
+      user_id: testUserId,
+      created_date: Date.now(),
+      status: {
+        id: 0,
+        name: "Pending",
+      },
+    },
+  ];
+  const multipleRequests = [
+    {
+      id: "testRequestId",
+      org_id: "testOrgId",
+      org_name: "testOrgName",
+      LegalName: "testOrgLegalName",
+      urn: "testOrgURN",
+      uid: "testOrgUID",
+      upin: "testOrgUPIN",
+      ukprn: "testOrgUKPRN",
+      org_status: {
+        id: 1,
+        name: "Open",
+      },
+      user_id: testUserId,
+      created_date: Date.now(),
+      status: {
+        id: 0,
+        name: "Pending",
+      },
+    },
+    {
+      id: "testRequestId2",
+      org_id: "testOrgId",
+      org_name: "testOrgName",
+      LegalName: "testOrgLegalName",
+      urn: "testOrgURN",
+      uid: "testOrgUID",
+      upin: "testOrgUPIN",
+      ukprn: "testOrgUKPRN",
+      org_status: {
+        id: 1,
+        name: "Open",
+      },
+      user_id: testUserId,
+      created_date: Date.now(),
+      status: {
+        id: 0,
+        name: "Pending",
+      },
+    },
+  ];
+
+  beforeEach(() => {
+    req = mockRequest({
+      user: {
+        id: testUserId,
+      },
+      userOrganisations: [],
+    });
+    res.mockResetAll();
+    getPendingRequestsAssociatedWithUser.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    getPendingRequestsAssociatedWithUser.mockReset();
+  });
+
+  it("it checks if the user has any pending organisation requests", async () => {
+    await canRequestOrg(req, res, () => {});
+
+    expect(getPendingRequestsAssociatedWithUser).toHaveBeenCalled();
+    expect(getPendingRequestsAssociatedWithUser).toHaveBeenCalledWith(
+      testUserId,
+    );
+  });
+
+  it.each([
+    {
+      requests: singleRequest,
+      requestMessage: "1 pending request",
+    },
+    {
+      requests: multipleRequests,
+      requestMessage: "multiple pending requests",
+    },
+  ])(
+    "it sets an appropriate flash message if the user has 0 orgs and $requestMessage",
+    async ({ requests }) => {
+      req.userOrganisations = [];
+      getPendingRequestsAssociatedWithUser.mockResolvedValue(requests);
+      await canRequestOrg(req, res, () => {});
+
+      expect(res.flash).toHaveBeenCalledTimes(3);
+      expect(res.flash).toHaveBeenCalledWith("title", "Important");
+      expect(res.flash).toHaveBeenCalledWith(
+        "heading",
+        "Your recent organisation request is awaiting approval.",
+      );
+      expect(res.flash).toHaveBeenCalledWith(
+        "message",
+        "You must wait for a response before submitting another request.",
+      );
+    },
+  );
+
+  it.each([
+    {
+      requests: singleRequest,
+      requestMessage: "1 pending request",
+    },
+    {
+      requests: multipleRequests,
+      requestMessage: "multiple pending requests",
+    },
+  ])(
+    "it redirects to the /organisations page if the user has 0 orgs and $requestMessage",
+    async ({ requests }) => {
+      req.userOrganisations = [];
+      getPendingRequestsAssociatedWithUser.mockResolvedValue(requests);
+      await canRequestOrg(req, res, () => {});
+
+      expect(res.sessionRedirect).toHaveBeenCalled();
+      expect(res.sessionRedirect).toHaveBeenCalledWith("/organisations");
+    },
+  );
+
+  it.each([
+    {
+      orgs: [],
+      requests: [],
+      orgMessage: "0 orgs",
+      requestMessage: "0 pending requests",
+    },
+    {
+      orgs: singleOrg,
+      requests: [],
+      orgMessage: "1 org",
+      requestMessage: "0 pending requests",
+    },
+    {
+      orgs: singleOrg,
+      requests: singleRequest,
+      orgMessage: "1 org",
+      requestMessage: "1 pending request",
+    },
+    {
+      orgs: singleOrg,
+      requests: multipleRequests,
+      orgMessage: "1 org",
+      requestMessage: "multiple pending requests",
+    },
+    {
+      orgs: multipleOrgs,
+      requests: [],
+      orgMessage: "multiple orgs",
+      requestMessage: "0 pending requests",
+    },
+    {
+      orgs: multipleOrgs,
+      requests: singleRequest,
+      orgMessage: "multiple orgs",
+      requestMessage: "1 pending request",
+    },
+    {
+      orgs: multipleOrgs,
+      requests: multipleRequests,
+      orgMessage: "multiple orgs",
+      requestMessage: "multiple pending requests",
+    },
+  ])(
+    "it runs the next middleware in the stack if the user has $orgMessage and $requestMessage",
+    async ({ orgs, requests }) => {
+      const next = jest.fn();
+      req.userOrganisations = orgs;
+      getPendingRequestsAssociatedWithUser.mockResolvedValue(requests);
+      await canRequestOrg(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+    },
+  );
+});


### PR DESCRIPTION
Ticket: https://dfe-secureaccess.atlassian.net/browse/NSA-8677

Changes:

- Create a middleware named `canRequestOrg` which checks if a user has any organisations and any active organisations requests and:
  - If the user has 0 orgs, and 1 or more active requests, they are redirected to `/organisations` with the appropriate message specified in the ticket.
  - If the user has 1 or more orgs, and 0, 1, or more active requests, they are allowed to go to the next middleware/page.
- Applied the above middleware to the `/request-organisation` routes.
- Unit tests for the `canRequestOrg` middleware.
- Updated the `/organisations` template to only display the notification banner in success colours (green) if the title contains "success" case-insensitive, otherwise it will display the default blue colours.