### PR TITLE
[DSI-7583] Remove reference to the DSI session timeout of 8 hours

### DIFF
--- a/src/app/home/home.js
+++ b/src/app/home/home.js
@@ -4,9 +4,6 @@ const config = require("../../infrastructure/config");
 const {
   checkCacheForAllServices,
 } = require("../../infrastructure/helpers/allServicesAppCache");
-const {
-  getMomentFormattedDuration,
-} = require("../helpers/durationFormatterHelper");
 
 const getAndMapExternalServices = async (correlationId) => {
   const allServices = await checkCacheForAllServices(correlationId);
@@ -40,8 +37,6 @@ const displayEsfa = (externalServices) => {
 
 const home = async (req, res) => {
   let services = await getAndMapExternalServices(req.id);
-  const sessionExpiryTime =
-    config.hostingEnvironment.sessionCookieExpiryInMinutes || 20;
 
   services = displayEsfa(services);
 
@@ -52,7 +47,6 @@ const home = async (req, res) => {
     profileUrl: config.hostingEnvironment.profileUrl,
     helpUrl: config.hostingEnvironment.helpUrl,
     helpAssistantUrl: config.hostingEnvironment.helpAssistantUrl,
-    sessionExpiryTime: getMomentFormattedDuration(sessionExpiryTime),
   });
 };
 

--- a/src/app/home/views/landingPage.ejs
+++ b/src/app/home/views/landingPage.ejs
@@ -60,7 +60,6 @@
                     </ol>
                 </div>
             </details>
-            <p class="govuk-body" id="inactivity-message">If you are inactive for <%= locals.sessionExpiryTime %>, your session will timeout.</p>
         </div>
     </div>
 </div>

--- a/test/unit/app/home/home.test.js
+++ b/test/unit/app/home/home.test.js
@@ -121,11 +121,4 @@ describe("when displaying current organisation and service mapping", () => {
       "https://localhost:3001/chatBot",
     );
   });
-
-  it("then it should include session expiry time in model", async () => {
-    await home(req, res);
-
-    expect(res.render.mock.calls).toHaveLength(1);
-    expect(res.render.mock.calls[0][1].sessionExpiryTime).toBe("20 minutes");
-  });
 });


### PR DESCRIPTION
## Summary
Jira ticket: [DSI-7583](https://dfe-secureaccess.atlassian.net/browse/DSI-7583)

## Changes
- Remove `sessionExpiryTime` from Email and Password pages

## Related PRs:
- 