### PR TITLE
[NSA-8953] Add role descriptions for roles where a service has `showRolesOnServices` set to "true".

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -736,14 +736,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha1-KPP7RSUvyI7y3FR8ipEcJV/J/vY=",
+      "version": "7.26.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/helpers/-/helpers-7.26.10.tgz",
+      "integrity": "sha1-a66jzWLsLQwQaHeNY8sTFPZjc4Q=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.26.10"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1074,9 +1074,9 @@
       "license": "MIT"
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha1-CLQ97HnujmgsKsYxwBC9ysVKIc4=",
+      "version": "7.26.10",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha1-OWOC9jNb1P62V0Hqz8gIIY+Fklk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/app/home/getServices.js
+++ b/src/app/home/getServices.js
@@ -62,6 +62,12 @@ const getAndMapServices = async (account, correlationId) => {
           services.push({
             id: role.id,
             name: role.name,
+            description:
+              application.relyingParty &&
+              application.relyingParty.params &&
+              application.relyingParty.params[`${role.code}_DESCRIPTION`]
+                ? application.relyingParty.params[`${role.code}_DESCRIPTION`]
+                : "",
             serviceUrl:
               application.relyingParty &&
               application.relyingParty.params &&


### PR DESCRIPTION
## Context

Ticket: https://dfe-secureaccess.atlassian.net/browse/NSA-8953

There is a service param that applies to the services component called `showRolesOnServices`, which services can have and allows their roles to be displayed as separate links instead of the service as a whole being displayed on the "My Services" page. The URLs for each role are set via service params with the role code as the name, and the URL as the value.

This is useful for form platforms for instance, but this change allows descriptions to be added as well as URLs.

## Changes

- Fixed a vulnerability found by `npm audit` using the automatic fix command.
- Added the ability for roles of a service with `showRolesOnServices` set to `"true"`, to have descriptions set by a service param with the name `ROLECODE_DESCRIPTION` or be an empty string if nothing is provided.
- Unit test changes:
  - Mocked the cache for the applications, so it doesn't interfere with the unit tests when mocking different return values, as these don't need to be cached.
  - Fixed 3 unit tests that broke when the cache was mocked, as they were relying on values set by the default mocked API call, not their own test versions and were expecting incorrect values.
  - Added unit tests for services with `showRolesOnServices` being set to `"true"` for the current functionality as well as the new description functionality.