### PR TITLE
[DSI-7513] Update login.dfe.validation package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "login.dfe.jwt-strategies": "^4.1.2",
         "login.dfe.policy-engine": "^3.1.4",
         "login.dfe.sanitization": "^3.0.4",
-        "login.dfe.validation": "github:DFE-Digital/login.dfe.validation#v2.1.3",
+        "login.dfe.validation": "^2.1.4",
         "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",
         "moment": "^2.30.1",
         "node-cache": "^5.1.2",
@@ -6928,12 +6928,13 @@
       }
     },
     "node_modules/login.dfe.validation": {
-      "version": "2.1.3",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.validation.git#0574e3423391b394d1c8cb55ae2a8b2c02afd37d",
+      "version": "2.1.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.validation/-/login.dfe.validation-2.1.4.tgz",
+      "integrity": "sha1-Yzn409GrYw7ZTyLhVYImQrGzkO4=",
       "license": "MIT",
       "dependencies": {
         "email-validator": "^2.0.4",
-        "express-validator": "^7.0.1"
+        "express-validator": "^7.2.1"
       }
     },
     "node_modules/login.dfe.winston-appinsights": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "login.dfe.jwt-strategies": "^4.1.2",
     "login.dfe.policy-engine": "^3.1.4",
     "login.dfe.sanitization": "^3.0.4",
-    "login.dfe.validation": "github:DFE-Digital/login.dfe.validation#v2.1.3",
+    "login.dfe.validation": "^2.1.4",
     "login.dfe.winston-appinsights": "github:DFE-Digital/login.dfe.winston-appinsights#v5.0.3",
     "moment": "^2.30.1",
     "node-cache": "^5.1.2",


### PR DESCRIPTION
## Summary
Jira ticket: 
- https://dfe-secureaccess.atlassian.net/browse/DSI-7513

### Changes
- Update `login.dfe.validation` to use version package "^2.1.4"


### Related PRs:
- https://github.com/DFE-Digital/login.dfe.validation/pull/27