### PR TITLE
[DSI-7862] Centralise Application APIs

### DIFF
--- a/src/app/home/getServices.js
+++ b/src/app/home/getServices.js
@@ -1,5 +1,4 @@
 const { getServicesForUser } = require("./../../infrastructure/access");
-const { getApplication } = require("./../../infrastructure/applications");
 const Account = require("./../../infrastructure/account");
 const appCache = require("./../../infrastructure/helpers/AppCache");
 const { directories } = require("login.dfe.dao");
@@ -23,6 +22,8 @@ const {
   isLoginOver24,
 } = require("../users/utils");
 const { actions } = require("../constans/actions");
+
+const { getServiceRaw } = require("login.dfe.api-client/services");
 
 const {
   getUserLatestActionedOrganisationRequestRaw,
@@ -48,7 +49,7 @@ const getAndMapServices = async (account, correlationId) => {
       let application = appCache.retrieve(service.id);
 
       if (!application) {
-        application = await getApplication(service.id);
+        application = await getServiceRaw({ by: { serviceId: service.id } });
         appCache.save(service.id, application);
         logger.info(`${service.id} adding to app cache`);
       } else {

--- a/src/app/requestService/requestEditRoles.js
+++ b/src/app/requestService/requestEditRoles.js
@@ -4,7 +4,7 @@ const {
   isMultipleRolesAllowed,
   RoleSelectionConstraintCheck,
 } = require("../users/utils");
-const { getApplication } = require("./../../infrastructure/applications");
+const { getServiceRaw } = require("login.dfe.api-client/services");
 const { actions } = require("../constans/actions");
 const PolicyEngine = require("login.dfe.policy-engine");
 const policyEngine = new PolicyEngine(config);
@@ -34,7 +34,9 @@ const getViewModel = async (req) => {
     a.name.localeCompare(b.name),
   );
   const numberOfRolesAvailable = serviceRoles.length;
-  const application = await getApplication(req.params.sid, req.id);
+  const application = await getServiceRaw({
+    by: { serviceId: req.params.sid },
+  });
 
   const allowedToSelectMoreThanOneRole = isMultipleRolesAllowed(
     application,

--- a/src/app/requestService/requestRoles.js
+++ b/src/app/requestService/requestRoles.js
@@ -3,12 +3,13 @@ const {
   isMultipleRolesAllowed,
   RoleSelectionConstraintCheck,
 } = require("../users/utils");
-const { getApplication } = require("../../infrastructure/applications");
 const {
   getOrganisationAndServiceForUserV2,
 } = require("../../infrastructure/organisations");
 const PolicyEngine = require("login.dfe.policy-engine");
 const logger = require("../../infrastructure/logger");
+const { getServiceRaw } = require("login.dfe.api-client/services");
+
 const policyEngine = new PolicyEngine(config);
 const renderAssociateRolesPage = (_req, res, model) => {
   return res.render("requestService/views/requestRoles", model);
@@ -25,7 +26,9 @@ const getViewModel = async (req) => {
     (x) => x.serviceId === req.params.sid,
   );
   const currentService = currentServiceIndex + 1;
-  const serviceDetails = await getApplication(req.params.sid, req.id);
+  const serviceDetails = await getServiceRaw({
+    by: { serviceId: req.params.sid },
+  });
   const organisationDetails = req.userOrganisations.find(
     (x) => x.organisation.id === req.params.orgId,
   );

--- a/src/app/users/associateRoles.js
+++ b/src/app/users/associateRoles.js
@@ -8,7 +8,7 @@ const {
   isMultipleRolesAllowed,
   RoleSelectionConstraintCheck,
 } = require("./utils");
-const { getApplication } = require("./../../infrastructure/applications");
+const { getServiceRaw } = require("login.dfe.api-client/services");
 const {
   getOrganisationAndServiceForUserV2,
 } = require("./../../infrastructure/organisations");
@@ -131,7 +131,9 @@ const getViewModel = async (req) => {
     (x) => x.serviceId === req.params.sid,
   );
   const currentService = currentServiceIndex + 1;
-  const serviceDetails = await getApplication(req.params.sid, req.id);
+  const serviceDetails = await getServiceRaw({
+    by: { serviceId: req.params.sid },
+  });
   const organisationDetails = req.userOrganisations.find(
     (x) => x.organisation.id === req.params.orgId,
   );

--- a/src/app/users/editServices.js
+++ b/src/app/users/editServices.js
@@ -8,7 +8,7 @@ const {
   isMultipleRolesAllowed,
   RoleSelectionConstraintCheck,
 } = require("./utils");
-const { getApplication } = require("./../../infrastructure/applications");
+const { getServiceRaw } = require("login.dfe.api-client/services");
 const { actions } = require("../constans/actions");
 const PolicyEngine = require("login.dfe.policy-engine");
 const policyEngine = new PolicyEngine(config);
@@ -64,7 +64,9 @@ const getViewModel = async (req) => {
     req.id,
   );
 
-  const application = await getApplication(req.params.sid, req.id);
+  const application = await getServiceRaw({
+    by: { serviceId: req.params.sid },
+  });
   const serviceRoles = policyResult.rolesAvailableToUser.sort((a, b) =>
     a.name.localeCompare(b.name),
   );

--- a/src/app/users/utils.js
+++ b/src/app/users/utils.js
@@ -6,7 +6,7 @@ const {
   getSingleUserService,
   getSingleInvitationService,
 } = require("./../../infrastructure/access");
-const { getApplication } = require("./../../infrastructure/applications");
+const { getServiceRaw } = require("login.dfe.api-client/services");
 const { actions } = require("../constans/actions");
 const moment = require("moment");
 const sortBy = require("lodash/sortBy");
@@ -52,7 +52,7 @@ const getAllServicesForUserInOrg = async (
   }));
   for (let i = 0; i < services.length; i++) {
     const service = services[i];
-    const application = await getApplication(service.id);
+    const application = await getServiceRaw({ by: { serviceId: service.id } });
     service.name = application.name;
     service.status = mapUserStatus(service.status);
   }
@@ -78,7 +78,9 @@ const getSingleServiceForUser = async (
         organisationId,
         correlationId,
       );
-  const application = await getApplication(userService.serviceId);
+  const application = await getServiceRaw({
+    by: { serviceId: userService.serviceId },
+  });
   return {
     id: userService.serviceId,
     roles: userService.roles,

--- a/src/infrastructure/applications/api.js
+++ b/src/infrastructure/applications/api.js
@@ -1,28 +1,4 @@
-const config = require("./../config");
-const { fetchApi } = require("login.dfe.async-retry");
-const jwtStrategy = require("login.dfe.jwt-strategies");
 const { services } = require("login.dfe.dao");
-
-const getApplication = async (idOrClientId, correlationId) => {
-  const token = await jwtStrategy(config.applications.service).getBearerToken();
-  try {
-    return await fetchApi(
-      `${config.applications.service.url}/services/${idOrClientId}`,
-      {
-        method: "GET",
-        headers: {
-          authorization: `bearer ${token}`,
-          "x-correlation-id": correlationId,
-        },
-      },
-    );
-  } catch (e) {
-    if (e.statusCode === 404) {
-      return undefined;
-    }
-    throw e;
-  }
-};
 
 const getPageOfService = async (pageNumber, pageSize) => {
   const pageOfServices = await services.list(pageNumber, pageSize);
@@ -56,7 +32,6 @@ const isServiceEmailNotificationAllowed = async () => {
 };
 
 module.exports = {
-  getApplication,
   getAllServices,
   isServiceEmailNotificationAllowed,
 };

--- a/src/infrastructure/applications/static.js
+++ b/src/infrastructure/applications/static.js
@@ -1,14 +1,3 @@
-const applications = [];
-
-const getApplication = async (idOrClientId) => {
-  return applications.find(
-    (a) =>
-      a.id.toLowerCase() === idOrClientId.toLowerCase() ||
-      (a.relyingParty &&
-        a.relyingParty.clientId.toLowerCase() === idOrClientId.toLowerCase()),
-  );
-};
-
 const getAllServices = async () => {
   return Promise.resolve([]);
 };
@@ -18,7 +7,6 @@ const isServiceEmailNotificationAllowed = async () => {
 };
 
 module.exports = {
-  getApplication,
   getAllServices,
   isServiceEmailNotificationAllowed,
 };

--- a/test/unit/app/home/getServices.test.js
+++ b/test/unit/app/home/getServices.test.js
@@ -3,9 +3,6 @@ jest.mock("./../../../../src/infrastructure/account", () => ({
   getUsersById: jest.fn(),
   getById: jest.fn(),
 }));
-jest.mock("./../../../../src/infrastructure/applications", () => ({
-  getApplication: jest.fn(),
-}));
 
 jest.mock("./../../../../src/infrastructure/access", () => ({
   getServicesForUser: jest.fn(),
@@ -15,9 +12,15 @@ jest.mock("login.dfe.api-client/users", () => ({
   getUserLatestActionedOrganisationRequestRaw: jest.fn(),
 }));
 
+jest.mock("login.dfe.api-client/services", () => ({
+  getServiceRaw: jest.fn(),
+}));
+
 const {
   getUserLatestActionedOrganisationRequestRaw,
 } = require("login.dfe.api-client/users");
+
+const { getServiceRaw } = require("login.dfe.api-client/services");
 
 jest.mock("./../../../../src/infrastructure/helpers/AppCache");
 
@@ -57,9 +60,7 @@ const Account = require("./../../../../src/infrastructure/account");
 const {
   getServicesForUser,
 } = require("./../../../../src/infrastructure/access");
-const {
-  getApplication,
-} = require("./../../../../src/infrastructure/applications");
+
 const {
   getOrganisationAndServiceForUser,
   getPendingRequestsAssociatedWithUser,
@@ -163,7 +164,7 @@ describe("when displaying the users services", () => {
       { id: "banner2", userId: "user1", serviceName: "Analysis reports" },
     ]);
 
-    getApplication.mockReset().mockReturnValue(application);
+    getServiceRaw.mockReset().mockReturnValue(application);
     Account.getById.mockReset().mockReturnValue({
       claims: {
         sub: "user1",
@@ -290,7 +291,7 @@ describe("when displaying the users services", () => {
         redirect_uris: ["http://service.one/login"],
       },
     };
-    getApplication.mockReset().mockReturnValue(application);
+    getServiceRaw.mockReset().mockReturnValue(application);
 
     await getServices(req, res);
 
@@ -306,7 +307,7 @@ describe("when displaying the users services", () => {
         redirect_uris: ["http://service.one/login/cb"],
       },
     };
-    getApplication.mockReset().mockReturnValue(application);
+    getServiceRaw.mockReset().mockReturnValue(application);
 
     await getServices(req, res);
 
@@ -335,7 +336,7 @@ describe("when displaying the users services", () => {
   });
 
   it("then it should set serviceUrl to # if no service_home or redirects available", async () => {
-    getApplication.mockReset().mockReturnValue({
+    getServiceRaw.mockReset().mockReturnValue({
       name: "Service One",
       relyingParty: {
         redirect_uris: [],
@@ -407,7 +408,7 @@ describe("when displaying the users services", () => {
       };
 
       getServicesForUser.mockReset().mockReturnValue(userAccess);
-      getApplication.mockReset().mockReturnValue(application);
+      getServiceRaw.mockReset().mockReturnValue(application);
     });
 
     it("then it will not pass the service itself when rendering the page", async () => {

--- a/test/unit/app/home/getServices.test.js
+++ b/test/unit/app/home/getServices.test.js
@@ -4,10 +4,6 @@ jest.mock("./../../../../src/infrastructure/account", () => ({
   getById: jest.fn(),
 }));
 
-jest.mock("./../../../../src/infrastructure/access", () => ({
-  getServicesForUser: jest.fn(),
-}));
-
 jest.mock("login.dfe.api-client/users", () => ({
   getUserServicesRaw: jest.fn(),
   getUserLatestActionedOrganisationRequestRaw: jest.fn(),
@@ -59,9 +55,6 @@ jest.mock("./../../../../src/infrastructure/organisations", () => ({
 
 const { mockRequest, mockResponse } = require("./../../../utils/jestMocks");
 const Account = require("./../../../../src/infrastructure/account");
-const {
-  getServicesForUser,
-} = require("./../../../../src/infrastructure/access");
 
 const {
   getOrganisationAndServiceForUser,

--- a/test/unit/app/requestService/requestEditRoles.get.test.js
+++ b/test/unit/app/requestService/requestEditRoles.get.test.js
@@ -3,18 +3,14 @@ jest.mock("./../../../../src/infrastructure/config", () =>
 );
 jest.mock("login.dfe.policy-engine");
 jest.mock("./../../../../src/app/users/utils");
-jest.mock("./../../../../src/infrastructure/applications", () => {
-  return {
-    getApplication: jest.fn(),
-  };
-});
+jest.mock("login.dfe.api-client/services", () => ({
+  getServiceRaw: jest.fn(),
+}));
 jest.mock("login.dfe.dao", () => require("../../../utils/jestMocks").mockDao());
 const { mockRequest, mockResponse } = require("../../../utils/jestMocks");
 const PolicyEngine = require("login.dfe.policy-engine");
 const { getSingleServiceForUser } = require("../../../../src/app/users/utils");
-const {
-  getApplication,
-} = require("../../../../src/infrastructure/applications");
+const { getServiceRaw } = require("login.dfe.api-client/services");
 const application = {
   name: "Service One",
   relyingParty: {
@@ -79,7 +75,7 @@ describe("when displaying the request edit service view", () => {
         },
       },
     ];
-    getApplication.mockReset().mockReturnValue(application);
+    getServiceRaw.mockReset().mockReturnValue(application);
     res = mockResponse();
 
     policyEngine.getPolicyApplicationResultsForUser

--- a/test/unit/app/requestService/requestEditRoles.post.test.js
+++ b/test/unit/app/requestService/requestEditRoles.post.test.js
@@ -3,19 +3,15 @@ jest.mock("../../../../src/infrastructure/config", () =>
 );
 jest.mock("login.dfe.policy-engine");
 jest.mock("../../../../src/app/users/utils");
-jest.mock("../../../../src/infrastructure/applications", () => {
-  return {
-    getApplication: jest.fn(),
-  };
-});
+jest.mock("login.dfe.api-client/services", () => ({
+  getServiceRaw: jest.fn(),
+}));
 jest.mock("login.dfe.dao", () => require("../../../utils/jestMocks").mockDao());
 
 const { mockRequest, mockResponse } = require("../../../utils/jestMocks");
 const PolicyEngine = require("login.dfe.policy-engine");
 const { getSingleServiceForUser } = require("../../../../src/app/users/utils");
-const {
-  getApplication,
-} = require("../../../../src/infrastructure/applications");
+const { getServiceRaw } = require("login.dfe.api-client/services");
 const application = {
   name: "Service One",
   relyingParty: {
@@ -81,7 +77,7 @@ describe("when displaying the request edit service view", () => {
         },
       },
     ];
-    getApplication.mockReset().mockReturnValue(application);
+    getServiceRaw.mockReset().mockReturnValue(application);
     res = mockResponse();
     policyEngine.validate.mockReset().mockReturnValue([]);
     policyEngine.getPolicyApplicationResultsForUser

--- a/test/unit/app/requestService/requestRoles.get.test.js
+++ b/test/unit/app/requestService/requestRoles.get.test.js
@@ -5,17 +5,13 @@ jest.mock("./../../../../src/infrastructure/config", () =>
 jest.mock("./../../../../src/infrastructure/logger", () =>
   require("./../../../utils/jestMocks").mockLogger(),
 );
-jest.mock("./../../../../src/infrastructure/applications", () => {
-  return {
-    getApplication: jest.fn(),
-  };
-});
+jest.mock("login.dfe.api-client/services", () => ({
+  getServiceRaw: jest.fn(),
+}));
 
 const { mockRequest, mockResponse } = require("./../../../utils/jestMocks");
 const PolicyEngine = require("login.dfe.policy-engine");
-const {
-  getApplication,
-} = require("./../../../../src/infrastructure/applications");
+const { getServiceRaw } = require("login.dfe.api-client/services");
 const logger = require("./../../../../src/infrastructure/logger");
 
 const policyEngine = {
@@ -116,8 +112,10 @@ describe("when displaying the sub-services view", () => {
 
   it("then it should get the service details", async () => {
     await getRequestRoles(req, res);
-    expect(getApplication.mock.calls).toHaveLength(1);
-    expect(getApplication.mock.calls[0][0]).toBe("service1");
+    expect(getServiceRaw.mock.calls).toHaveLength(1);
+    expect(getServiceRaw.mock.calls[0][0]).toMatchObject({
+      by: { serviceId: "service1" },
+    });
   });
 
   it("then it should redirect the user to /my-services and log a warning message if user services do not exist in the session", async () => {

--- a/test/unit/app/users/getAssociateRoles.test.js
+++ b/test/unit/app/users/getAssociateRoles.test.js
@@ -5,11 +5,9 @@ jest.mock("./../../../../src/infrastructure/config", () =>
 jest.mock("./../../../../src/infrastructure/logger", () =>
   require("./../../../utils/jestMocks").mockLogger(),
 );
-jest.mock("./../../../../src/infrastructure/applications", () => {
-  return {
-    getApplication: jest.fn(),
-  };
-});
+jest.mock("login.dfe.api-client/services", () => ({
+  getServiceRaw: jest.fn(),
+}));
 jest.mock("./../../../../src/infrastructure/organisations", () => {
   return {
     getOrganisationAndServiceForUserV2: jest.fn(),
@@ -30,9 +28,7 @@ const {
   mockConfig,
 } = require("./../../../utils/jestMocks");
 const PolicyEngine = require("login.dfe.policy-engine");
-const {
-  getApplication,
-} = require("./../../../../src/infrastructure/applications");
+const { getServiceRaw } = require("login.dfe.api-client/services");
 const {
   getOrganisationAndServiceForUserV2,
 } = require("./../../../../src/infrastructure/organisations");
@@ -250,8 +246,10 @@ describe("when displaying the associate roles view", () => {
 
   it("then it should get the service details", async () => {
     await getAssociateRoles(req, res);
-    expect(getApplication.mock.calls).toHaveLength(1);
-    expect(getApplication.mock.calls[0][0]).toBe("service1");
+    expect(getServiceRaw.mock.calls).toHaveLength(1);
+    expect(getServiceRaw.mock.calls[0][0]).toMatchObject({
+      by: { serviceId: "service1" },
+    });
   });
 
   it('then it gets the correct "Cancel" redirect link when adding new service to an end user', async () => {
@@ -367,7 +365,7 @@ describe("when displaying the associate roles view", () => {
   });
 
   it("then it should call RoleSelectionConstraintCheck if there are any role selection constraints", async () => {
-    getApplication.mockReset().mockReturnValue({
+    getServiceRaw.mockReset().mockReturnValue({
       relyingParty: {
         params: {
           allowManageInvite: "true",

--- a/test/unit/app/users/getEditServices.test.js
+++ b/test/unit/app/users/getEditServices.test.js
@@ -3,11 +3,9 @@ jest.mock("./../../../../src/infrastructure/config", () =>
 );
 jest.mock("login.dfe.policy-engine");
 jest.mock("./../../../../src/app/users/utils");
-jest.mock("./../../../../src/infrastructure/applications", () => {
-  return {
-    getApplication: jest.fn(),
-  };
-});
+jest.mock("login.dfe.api-client/services", () => ({
+  getServiceRaw: jest.fn(),
+}));
 
 const { mockRequest, mockResponse } = require("./../../../utils/jestMocks");
 const PolicyEngine = require("login.dfe.policy-engine");
@@ -18,9 +16,7 @@ const {
   isUserManagement,
   isReviewSubServiceRequest,
 } = require("./../../../../src/app/users/utils");
-const {
-  getApplication,
-} = require("./../../../../src/infrastructure/applications");
+const { getServiceRaw } = require("login.dfe.api-client/services");
 const application = {
   name: "Service One",
   relyingParty: {
@@ -91,7 +87,7 @@ describe("when displaying the edit service view", () => {
         },
       },
     ];
-    getApplication.mockReset().mockReturnValue(application);
+    getServiceRaw.mockReset().mockReturnValue(application);
     getUserDetails.mockReset().mockReturnValue(user);
     res = mockResponse();
 

--- a/test/unit/app/users/postAssociateRoles.test.js
+++ b/test/unit/app/users/postAssociateRoles.test.js
@@ -10,6 +10,7 @@ jest.mock("./../../../../src/infrastructure/organisations", () => {
     getOrganisationAndServiceForUserV2: jest.fn(),
   };
 });
+jest.mock("login.dfe.api-client/services");
 
 const {
   mockRequest,


### PR DESCRIPTION
### Summary
Jira ticket https://dfe-secureaccess.atlassian.net/browse/DSI-7862

### Changes
- Remove local implementation of `getApplication` and use `getServiceRaw` from `login.dfe.api-client/services`
- Update tests