### PR TITLE
Add service when an admin deactivates a user

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,27 @@ const {
 const { setupApi } = require("login.dfe.api-client/api/setup");
 const packageConfig = require("../package.json");
 const registerRoutes = require("./routes");
+const Redis = require("ioredis");
+
+// Dedicated connection to the OIDC Redis DB (DB 0, `dsi:` namespace) used
+// solely to read the per-user deactivation kill switch written by the OIDC
+// service when an admin deactivates a user.  This is intentionally separate
+// from the session-store connection (DB 3) so a DB-index mismatch cannot
+// silently skip the kill-switch check.
+const oidcRedisConnString =
+  process.env.LOCAL_REDIS_CONN || process.env.REDIS_CONN;
+const oidcKillSwitchClient = new Redis(oidcRedisConnString, {
+  tls: oidcRedisConnString?.includes("6380"),
+  lazyConnect: true,
+});
+
+const hasJwtExpired = (exp) => {
+  if (!exp) {
+    return true;
+  }
+  const expires = new Date(Date.UTC(1970, 0, 1) + exp * 1000).getTime();
+  return expires < Date.now();
+};
 
 https.globalAgent.maxSockets = http.globalAgent.maxSockets =
   config.hostingEnvironment.agentKeepAlive.maxSockets || 50;
@@ -89,33 +110,6 @@ redisClient.on("error", function (err) {
 redisClient.on("connect", function () {
   console.log("Connected to redis successfully");
 });
-
-// Dedicated connection to the OIDC Redis DB (DB 0, `dsi:` namespace) used
-// solely to read the per-user deactivation kill switch written by the OIDC
-// service when an admin deactivates a user.
-const oidcKillSwitchConnString = process.env.LOCAL_REDIS_CONN || process.env.REDIS_CONN;
-const oidcKillSwitchClient = createClient({
-  url: oidcKillSwitchConnString,
-  socket: {
-    tls: oidcKillSwitchConnString?.includes("6380"),
-  },
-});
-oidcKillSwitchClient
-  .connect()
-  .catch((err) =>
-    logger.warn(`Kill switch Redis connect failed: ${err.message}`),
-  );
-oidcKillSwitchClient.on("error", (err) =>
-  logger.warn(`Kill switch Redis error: ${err.message}`),
-);
-
-const hasJwtExpired = (exp) => {
-  if (!exp) {
-    return true;
-  }
-  const expires = new Date(Date.UTC(1970, 0, 1) + exp * 1000).getTime();
-  return expires < Date.now();
-};
 
 const init = async () => {
   let expiryInMinutes = 20;
@@ -291,8 +285,17 @@ const init = async () => {
   passport.serializeUser((user, done) => {
     done(null, user);
   });
+
   // Async deserializeUser: checks the OIDC kill switch before restoring the
-  // session.  Fails open so a Redis hiccup does not lock out active users.
+  // session.  If the OIDC service has written `dsi:KillSwitch:{userId}` to
+  // Redis (set during user deactivation), this returns null immediately,
+  // causing Passport to treat the request as unauthenticated and redirecting
+  // the user to re-authenticate — where the OIDC provider will deny access
+  // because Account.findById returns null for deactivated users.
+  //
+  // The kill switch check fails OPEN: if Redis is unreachable or the key is
+  // absent, we fall through to the normal expiry check so that a Redis hiccup
+  // does not lock out legitimate users.
   passport.deserializeUser(async (user, done) => {
     try {
       if (hasJwtExpired(user.exp)) {
@@ -321,6 +324,7 @@ const init = async () => {
       return done(null, user);
     }
   });
+
   app.use(passport.initialize());
   app.use(passport.session());
   app.use(setUserContext);

--- a/src/infrastructure/oidc/index.js
+++ b/src/infrastructure/oidc/index.js
@@ -36,6 +36,7 @@ const getPassportStrategy = async () => {
           userInfo.id = userInfo.sub;
           userInfo.name = userInfo.sub;
           userInfo.id_token = tokenset.id_token;
+          userInfo.exp = tokenset.claims().exp;
 
           done(null, userInfo);
         })


### PR DESCRIPTION
When an admin deactivated a user, a KillSwitch:{userId} key was written to Redis DB 0 with an 8-hour TTL. On reactivation, nothing removed that key, so all platform services continued to reject the user's sign-in attempts via deserializeUser until the TTL expired naturally.