### PR TITLE
fix(NSA-9674): block self-access updates from multi-tab invite sessio…

### DIFF
--- a/src/app/users/confirmNewUser.js
+++ b/src/app/users/confirmNewUser.js
@@ -154,9 +154,7 @@ const post = async (req, res) => {
     invitedEmail === currentUserEmail;
 
   if (isInviteJourney && (hasUidConflict || hasEmailConflict)) {
-    logger.warn(
-      "Blocked confirmNewUser due to invite session conflict; approver matched invited user and was redirected to /approvals/users",
-    );
+    logger.warn("DEVELOPER TO UPDATE");
     return res.redirect("/approvals/users");
   }
 

--- a/src/app/users/confirmNewUser.js
+++ b/src/app/users/confirmNewUser.js
@@ -29,6 +29,13 @@ const {
 } = require("./../../infrastructure/helpers/allServicesAppCache");
 const { actions } = require("../constants/actions");
 
+const normalizeForComparison = (value) => {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value.trim().toLowerCase();
+};
+
 const renderConfirmNewUserPage = (req, res, model) => {
   const isSelfManage = isSelfManagement(req);
   res.render(
@@ -128,6 +135,28 @@ const post = async (req, res) => {
   }
   if (!req.userOrganisations) {
     logger.warn("No req.userOrganisations on post of confirmNewUser");
+    return res.redirect("/approvals/users");
+  }
+
+  // Prevent multi-tab session conflicts from allowing approvers to update themselves.
+  const isInviteJourney = req.session?.user?.isInvite === true;
+  const invitedUid = normalizeForComparison(req.session?.user?.uid);
+  const currentUserSub = normalizeForComparison(req.user?.sub);
+  const invitedEmail = normalizeForComparison(req.session?.user?.email);
+  const currentUserEmail = normalizeForComparison(req.user?.email);
+  const hasUidConflict =
+    invitedUid.length > 0 &&
+    currentUserSub.length > 0 &&
+    invitedUid === currentUserSub;
+  const hasEmailConflict =
+    invitedEmail.length > 0 &&
+    currentUserEmail.length > 0 &&
+    invitedEmail === currentUserEmail;
+
+  if (isInviteJourney && (hasUidConflict || hasEmailConflict)) {
+    logger.warn(
+      "Blocked confirmNewUser due to invite session conflict; approver matched invited user and was redirected to /approvals/users",
+    );
     return res.redirect("/approvals/users");
   }
 

--- a/test/unit/app/users/postConfirmNewUser.test.js
+++ b/test/unit/app/users/postConfirmNewUser.test.js
@@ -8,6 +8,11 @@ jest.mock("./../../../../src/infrastructure/logger", () => mockLogger());
 jest.mock("./../../../../src/infrastructure/config", () => {
   return mockAdapterConfig();
 });
+jest.mock("./../../../../src/infrastructure/applications", () => {
+  return {
+    isServiceEmailNotificationAllowed: jest.fn(),
+  };
+});
 jest.mock("login.dfe.dao", () => {
   return {
     services: {
@@ -100,6 +105,9 @@ const {
 const {
   checkCacheForAllServices,
 } = require("./../../../../src/infrastructure/helpers/allServicesAppCache");
+const {
+  isServiceEmailNotificationAllowed,
+} = require("./../../../../src/infrastructure/applications");
 const Account = require("./../../../../src/infrastructure/account");
 const logger = require("./../../../../src/infrastructure/logger");
 
@@ -292,6 +300,8 @@ describe("when inviting a new user", () => {
         },
       },
     ]);
+    isServiceEmailNotificationAllowed.mockReset();
+    isServiceEmailNotificationAllowed.mockResolvedValue(true);
     postConfirmNewUser =
       require("./../../../../src/app/users/confirmNewUser").post;
     sendUserAddedToOrganisationStub.mockReset();
@@ -321,6 +331,49 @@ describe("when inviting a new user", () => {
     expect(Account.createInvite.mock.calls[0][0]).toBe("test");
     expect(Account.createInvite.mock.calls[0][1]).toBe("name");
     expect(Account.createInvite.mock.calls[0][2]).toBe("test@test.com");
+  });
+
+  it("then it should warn and redirect if invite UID matches current user sub", async () => {
+    req.session.user.isInvite = true;
+    req.session.user.uid = "USER1";
+    req.user.sub = "user1";
+
+    await postConfirmNewUser(req, res);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Blocked confirmNewUser due to invite session conflict; approver matched invited user and was redirected to /approvals/users",
+    );
+    expect(res.redirect).toHaveBeenCalledWith("/approvals/users");
+    expect(getOrganisationById).not.toHaveBeenCalled();
+    expect(Account.createInvite).not.toHaveBeenCalled();
+    expect(putInvitationInOrganisation).not.toHaveBeenCalled();
+    expect(putUserInOrganisation).not.toHaveBeenCalled();
+    expect(addServiceToInvitation).not.toHaveBeenCalled();
+    expect(addServiceToUser).not.toHaveBeenCalled();
+    expect(updateUserDetailsInSearchIndex).not.toHaveBeenCalled();
+    expect(updateUserInSearchIndex).not.toHaveBeenCalled();
+  });
+
+  it("then it should warn and redirect if invite email matches current user email", async () => {
+    req.session.user.isInvite = true;
+    req.session.user.uid = undefined;
+    req.session.user.email = "USER.ONE@UNIT.TEST";
+    req.user.email = "user.one@unit.test";
+
+    await postConfirmNewUser(req, res);
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Blocked confirmNewUser due to invite session conflict; approver matched invited user and was redirected to /approvals/users",
+    );
+    expect(res.redirect).toHaveBeenCalledWith("/approvals/users");
+    expect(getOrganisationById).not.toHaveBeenCalled();
+    expect(Account.createInvite).not.toHaveBeenCalled();
+    expect(putInvitationInOrganisation).not.toHaveBeenCalled();
+    expect(putUserInOrganisation).not.toHaveBeenCalled();
+    expect(addServiceToInvitation).not.toHaveBeenCalled();
+    expect(addServiceToUser).not.toHaveBeenCalled();
+    expect(updateUserDetailsInSearchIndex).not.toHaveBeenCalled();
+    expect(updateUserInSearchIndex).not.toHaveBeenCalled();
   });
 
   it("then it should add invitation to organisation", async () => {
@@ -529,6 +582,7 @@ describe("when inviting a new user", () => {
     req.params.uid = "user1";
     req.session.user.uid = "user1";
     req.session.user.isInvite = true;
+    req.user.sub = "approver1";
 
     await postConfirmNewUser(req, res);
 
@@ -552,6 +606,7 @@ describe("when inviting a new user", () => {
     req.params.uid = "user1";
     req.session.user.uid = "user1";
     req.session.user.isInvite = true;
+    req.user.sub = "approver1";
 
     await postConfirmNewUser(req, res);
 

--- a/test/unit/app/users/postConfirmNewUser.test.js
+++ b/test/unit/app/users/postConfirmNewUser.test.js
@@ -340,9 +340,7 @@ describe("when inviting a new user", () => {
 
     await postConfirmNewUser(req, res);
 
-    expect(logger.warn).toHaveBeenCalledWith(
-      "Blocked confirmNewUser due to invite session conflict; approver matched invited user and was redirected to /approvals/users",
-    );
+    expect(logger.warn).toHaveBeenCalledWith("DEVELOPER TO UPDATE");
     expect(res.redirect).toHaveBeenCalledWith("/approvals/users");
     expect(getOrganisationById).not.toHaveBeenCalled();
     expect(Account.createInvite).not.toHaveBeenCalled();
@@ -362,9 +360,7 @@ describe("when inviting a new user", () => {
 
     await postConfirmNewUser(req, res);
 
-    expect(logger.warn).toHaveBeenCalledWith(
-      "Blocked confirmNewUser due to invite session conflict; approver matched invited user and was redirected to /approvals/users",
-    );
+    expect(logger.warn).toHaveBeenCalledWith("DEVELOPER TO UPDATE");
     expect(res.redirect).toHaveBeenCalledWith("/approvals/users");
     expect(getOrganisationById).not.toHaveBeenCalled();
     expect(Account.createInvite).not.toHaveBeenCalled();


### PR DESCRIPTION
**Changes**

- src/app/users/confirmNewUser.js
  Added an early-return guard at the top of the POST handler. If req.session.user.isInvite is true and the invited user's UID or email (case-insensitive) matches the currently logged-in approver's sub or email, the handler logs a warning ("DEVELOPER TO UPDATE"), redirects to /approvals/users, and exits before any user/permission/service updates are persisted.

- test/unit/app/users/postConfirmNewUser.test.js
  Added two unit tests for the new conflict guard:
  - UID-conflict path
  - Email-conflict path

 - Also mocked isServiceEmailNotificationAllowed to return true deterministically in this spec, and updated two existing notification tests to use a distinct approver sub so they validate normal notification behavior and do not accidentally trigger the conflict guard.