### PR TITLE
[NSA-8797] fix: exclude approver from search index query to fix pagination counts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2641,9 +2641,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
+      "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha1-BJMzi91Y4xmxA5xnz37kOYksAdk=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2669,13 +2669,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha1-10+d1rV9g9jpjPuCEzsDl4vJKeU=",
+      "version": "9.0.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha1-mwy5/LeAh/b9fqur4lEcTT1gV04=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2825,9 +2825,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
+      "version": "6.14.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha1-/QZ3E+IoIQY267CMYL03Zdbb5zo=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3239,9 +3239,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha1-q5tFRGblqMw6GHvqrVgEEqnFuEM=",
+      "version": "1.1.13",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha1-03h1wB3J7/mI3UnREqV8tntU7+Y=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4171,9 +4171,9 @@
       }
     },
     "node_modules/dottie": {
-      "version": "2.0.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/dottie/-/dottie-2.0.6.tgz",
-      "integrity": "sha1-NFZOv8bsXldyJy1GZCStW2lkhNQ=",
+      "version": "2.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/dottie/-/dottie-2.0.7.tgz",
+      "integrity": "sha1-/RtGWhIRs11WYOlbabttW1gJs8Q=",
       "license": "MIT"
     },
     "node_modules/dunder-proto": {
@@ -4834,10 +4834,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-xml-parser": {
-      "version": "5.3.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
-      "integrity": "sha1-BvOar//byXvvAyHmJsfd0GoEPs8=",
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.4",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha1-DEB6HZ1ZljNsDNdvf/eFysZBMBc=",
       "funding": [
         {
           "type": "github",
@@ -4846,7 +4846,24 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^2.1.0"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
+      "integrity": "sha1-5ZY3q+vsPb+7QFO1MteHr26hFSc=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -4901,18 +4918,18 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha1-VPxTI3phPYVMe9N0Y6rRffhyFOc=",
+      "version": "2.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha1-BJMzi91Y4xmxA5xnz37kOYksAdk=",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha1-HPy4z1Ui6mmVLNKvla4JR38SKpY=",
+      "version": "5.1.9",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha1-EpPvFdsAmLOUVA6Pn3RPn9qN7ks=",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -4984,9 +5001,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha1-Z8j62VRUp8er6/dLt47nSkQCM1g=",
+      "version": "3.4.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha1-9cI8EH8PN96NvfJPE3IrO5jVJyY=",
       "dev": true,
       "license": "ISC"
     },
@@ -7078,9 +7095,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha1-8ROwN4OGEDvk9okziMc9C95/LFo=",
+      "version": "4.18.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha1-/ytmwfYybVlRPeJAe/iBQ5gSdxw=",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -7279,9 +7296,9 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.api-client": {
-      "version": "1.0.58",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.58.tgz",
-      "integrity": "sha1-0cldqLEURJxO772XNU2rhEsySow=",
+      "version": "1.0.63",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.63.tgz",
+      "integrity": "sha1-B+9RuvLcAbQUywyRL+gDROyLiVg=",
       "dependencies": {
         "@azure/msal-node": "^3.1.0",
         "applicationinsights": "^2.9.6",
@@ -7640,9 +7657,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha1-Gc0ZS/0+Qo8EmnCBfAONiatL41s=",
+      "version": "3.1.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha1-WAyI+NVEXyvWqo88re+g3nn71p4=",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8173,6 +8190,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.2.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha1-m9rjeH9DsIV7AmnpyqpYbBLIq+4=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -8200,9 +8232,9 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha1-1eGhLkeKl21DLvPFjVNLmSMWS7c=",
+      "version": "0.1.13",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha1-myLsFrw6uI0FoMfjaYaUIUAasX0=",
       "license": "MIT"
     },
     "node_modules/pause": {
@@ -8306,9 +8338,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha1-O6ODNzNkbZ0+SZWUbBNlpn+wekI=",
+      "version": "2.3.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha1-WpQpFeJrNy3A8OZ1MUmhbmscVgE=",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8604,9 +8636,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha1-pB2FudOQLzHSeGF5BQYpSIGHEVk=",
+      "version": "6.14.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha1-tWNM+dmtmJjjH7o1BOhm6O+2eYw=",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -9177,9 +9209,9 @@
       "license": "MIT"
     },
     "node_modules/sequelize": {
-      "version": "6.37.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize/-/sequelize-6.37.7.tgz",
-      "integrity": "sha1-Vab4VVrnbB+9S852sqxfzAoebrY=",
+      "version": "6.37.8",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sequelize/-/sequelize-6.37.8.tgz",
+      "integrity": "sha1-cOYsnmgqIAkAUJMQRZHlnsLQ7Sw=",
       "funding": [
         {
           "type": "opencollective",
@@ -9713,9 +9745,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strnum/-/strnum-2.1.1.tgz",
-      "integrity": "sha1-zypuDPkDcouLLEuXG342tOgtRqs=",
+      "version": "2.2.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha1-8R/ZSrYrU2ui7MYVhY83R8KIGz8=",
       "funding": [
         {
           "type": "github",
@@ -10342,9 +10374,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha1-GHCqArYx9+gyi5P4vFdPrF1sTXk=",
+      "version": "2.8.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha1-oNa9Lvs90DxZNwIjcBg05gQJvX0=",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -10352,6 +10384,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "he": "^1.2.0",
     "helmet": "^7.2.0",
     "lodash": "^4.17.21",
-    "login.dfe.api-client": "^1.0.58",
+    "login.dfe.api-client": "^1.0.63",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.transporter": "^4.0.4",
     "login.dfe.config.schema.common": "^2.1.8",

--- a/src/app/users/usersList.js
+++ b/src/app/users/usersList.js
@@ -47,6 +47,7 @@ const search = async (req) => {
       pageNumber: page,
       filterBy: {
         organisationIds: filteredOrgIds,
+        excludeId: req.user.sub,
       },
       searchFields: ["firstName", "lastName"],
       sortBy,
@@ -57,21 +58,11 @@ const search = async (req) => {
       pageNumber: page,
       filterBy: {
         organisationIds: filteredOrgIds,
+        excludeId: req.user.sub,
       },
       sortBy,
       sortDirection: sortAsc ? "asc" : "desc",
     });
-  }
-
-  if (usersForOrganisation.users.length) {
-    const users = usersForOrganisation.users.filter(
-      (item) => item.id !== req.user.sub,
-    );
-    if (users.length == 0) {
-      usersForOrganisation.numberOfPages = 0;
-      usersForOrganisation.totalNumberOfResults = 0;
-    }
-    usersForOrganisation.users = users;
   }
 
   for (let i = 0; i < usersForOrganisation.users.length; i++) {


### PR DESCRIPTION
## Summary

- Fixes INC01588001 — "Manage Users" pagination shows incorrect "Showing X - Y of Z rows" text for approvers
- The approver viewing the page was previously excluded client-side after the search response, leaving `totalNumberOfResults` and `numberOfPages` inflated by 1
- On multi-page result sets this caused the lower-bound calculation to drift on every page after the one where the approver appeared

## Changes

- **login.dfe.search**: Added `mode: 'exclude'` support to the filter pipeline, which generates an OData `ne` expression (`id ne 'value'`) in the Azure Search query. The `exclude_id` request parameter is parsed in the users search handler and passed as an exclude filter.
- **login.dfe.api-client**: Added `excludeId` to `UserSearchFilter` interface, mapped to `exclude_id` in the search request payload.
- **login.dfe.services**: Passes `excludeId: req.user.sub` in both `searchUsersRaw` calls. Removed the post-search client-side filter that was the previous incomplete workaround.

## Test plan

- [ ] Approver with <25 users in scope: "Showing 1 - N of N rows" (no off-by-one)
- [ ] Approver with >25 users where they appear on page 1: page 1 shows 25 results, subsequent pages have correct sequential bounds
- [ ] Approver with >25 users where they appear on page 2+: page 2 shows 25 results (not 24), page 3 starts from the correct position
- [ ] Approver's own account does not appear on any page
- [ ] Non-approver users and other search filters are unaffected