### PR TITLE
[NSA-9756]: update meta description for DfE Sign-in landing page

### DIFF
--- a/src/app/layouts/layout.ejs
+++ b/src/app/layouts/layout.ejs
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#1d70b8">
     <meta name="keywords" content="DfE Sign-In, Secure Access, DfE Login, Key to Success, Analyse School Performance, Teacher services, Teaching jobs, Trainee Teacher Portal, Collect, Get Information About Schools, Information exchange, Post 16 portal, School to School, Publish teacher training courses">
-    <meta name="description" content ="Use DfE Sign-in to login to services including Analyse School Performance, COLLECT, Key to Success and other services previously accessed through Secure Access.">
+    <meta name="description" content ="Department for Education (DfE) Sign-in is how schools and other education organisations access DfE online services.">
 
     <% if((locals.validationMessages && Object.keys(locals.validationMessages).length !==0) || 
            (locals.validations && Object.keys(locals.validations).length !==0 )) { %>

--- a/src/app/layouts/layout.ejs
+++ b/src/app/layouts/layout.ejs
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#1d70b8">
     <meta name="keywords" content="DfE Sign-In, Secure Access, DfE Login, Key to Success, Analyse School Performance, Teacher services, Teaching jobs, Trainee Teacher Portal, Collect, Get Information About Schools, Information exchange, Post 16 portal, School to School, Publish teacher training courses">
-    <meta name="description" content ="Department for Education (DfE) Sign-in is how schools and other education organisations access DfE online services.">
+    <meta name="description" content="Department for Education (DfE) Sign-in is how schools and other education organisations access DfE online services.">
 
     <% if((locals.validationMessages && Object.keys(locals.validationMessages).length !==0) || 
            (locals.validations && Object.keys(locals.validations).length !==0 )) { %>


### PR DESCRIPTION
Update the global meta description to reflect DfE Sign-in's purpose for schools and education organisations accessing online services. This improves the Google search snippet for https://services.signin.education.gov.uk

Changes Made:

Updated global meta description in layout.ejs (line 10)

New description: "Department for Education (DfE) Sign-in is how schools and other education organisations access DfE online services."

Verified the on-page introductory text in landingPage.ejs already matched the required wording.
