### PR TITLE
[NSA-8797] Fix manage users pagination lower bound drift caused by post-search filtering

### DIFF
--- a/src/app/layouts/pagination.ejs
+++ b/src/app/layouts/pagination.ejs
@@ -3,7 +3,9 @@ const pages = locals.numberOfPages;
 const page = locals.page;
 const numberOfResultsOnPagePage = locals.numberOfResultsOnPage;
 const totalNumberOfResults = locals.totalNumberOfResults
-let lowerEndRecords = page === pages ? totalNumberOfResults - numberOfResultsOnPagePage + 1 : numberOfResultsOnPagePage * (page - 1) + 1
+let lowerEndRecords = locals.pageStartPosition !== undefined
+    ? locals.pageStartPosition
+    : (page === pages ? totalNumberOfResults - numberOfResultsOnPagePage + 1 : numberOfResultsOnPagePage * (page - 1) + 1)
 const upperEndRecords = lowerEndRecords + numberOfResultsOnPagePage - 1
 
 if (locals.totalNumberOfResults === 0) {

--- a/src/app/layouts/pagination.ejs
+++ b/src/app/layouts/pagination.ejs
@@ -6,7 +6,9 @@ const totalNumberOfResults = locals.totalNumberOfResults
 let lowerEndRecords = locals.pageStartPosition !== undefined
     ? locals.pageStartPosition
     : (page === pages ? totalNumberOfResults - numberOfResultsOnPagePage + 1 : numberOfResultsOnPagePage * (page - 1) + 1)
-const upperEndRecords = lowerEndRecords + numberOfResultsOnPagePage - 1
+const upperEndRecords = locals.pageStartPosition !== undefined
+    ? Math.min(locals.pageStartPosition + 24, totalNumberOfResults)
+    : lowerEndRecords + numberOfResultsOnPagePage - 1
 
 if (locals.totalNumberOfResults === 0) {
     lowerEndRecords = 0;

--- a/src/app/users/usersList.js
+++ b/src/app/users/usersList.js
@@ -102,6 +102,7 @@ const search = async (req) => {
 
   return {
     page,
+    pageStartPosition: (page - 1) * 25 + 1,
     sortBy,
     sortOrder: sortAsc ? "asc" : "desc",
     usersForOrganisation,
@@ -181,6 +182,7 @@ const get = async (req, res) => {
     selectedOrganisations: result.selectedOrganisations,
     usersForOrganisation: result.usersForOrganisation,
     page: result.page,
+    pageStartPosition: result.pageStartPosition,
     sort: result.sort,
     sortBy: result.sortBy,
     sortOrder: result.sortOrder,
@@ -251,6 +253,7 @@ const post = async (req, res) => {
     selectedOrganisations: result.selectedOrganisations,
     usersForOrganisation: result.usersForOrganisation,
     page: result.page,
+    pageStartPosition: result.pageStartPosition,
     sort: result.sort,
     sortBy: result.sortBy,
     sortOrder: result.sortOrder,

--- a/src/app/users/views/usersList.ejs
+++ b/src/app/users/views/usersList.ejs
@@ -175,6 +175,7 @@
         numberOfPages: locals.numberOfPages,
         totalNumberOfResults: locals.totalNumberOfResults,
         numberOfResultsOnPage: locals.usersForOrganisation.users.length,
+        pageStartPosition: locals.pageStartPosition,
         data: [
             { key: 'searchCriteria', value: locals.searchCriteria },
             { key: 'sort', value: locals.sortBy },


### PR DESCRIPTION
## Summary

- Fixes pagination "Showing X – Y of Z rows" text drifting on pages after one where `filterDuplicateUsers` removes a stale `inv-{id}` record from results
- Root cause: the lower-bound formula `numberOfResultsOnPage * (page - 1) + 1` uses the post-filter result count, which drops to 24 when a duplicate is removed, causing all subsequent pages to start at the wrong position
- Fix: pass the Azure skip offset (`(page - 1) * 25 + 1`) from the controller through to `pagination.ejs` as `pageStartPosition` and use it as the lower bound — this is always correct regardless of client-side filtering

## Changes

- `usersList.js`: compute and return `pageStartPosition`
- `usersList.ejs`: pass `pageStartPosition` into the pagination model
- `pagination.ejs`: use `pageStartPosition` when provided; falls back to existing formula for other views that don't supply it (backwards-compatible)

## Test plan
- [x] Page 1 of Manage Users shows "Showing 1 – 25 of N rows"
- [x] Page with a duplicate removed (e.g. page 9 in pre-prod) shows correct sequential lower bound, not 193
- [x] Subsequent pages after the duplicate-removal page are not shifted
- [x] Requests and Request Organisation pagination views are unaffected