### PR TITLE
NSA-9817: Fix multi-tab session conflict in add-service + invite flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "he": "^1.2.0",
         "helmet": "^7.2.0",
         "lodash": "^4.17.21",
-        "login.dfe.api-client": "^1.0.58",
+        "login.dfe.api-client": "^1.0.63",
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
         "login.dfe.audit.transporter": "^4.0.4",
         "login.dfe.config.schema.common": "^2.1.8",
@@ -31,7 +31,7 @@
         "login.dfe.express-helpers": "^2.0.0",
         "login.dfe.healthcheck": "^3.0.3",
         "login.dfe.jobs-client": "^6.1.3",
-        "login.dfe.policy-engine": "^4.0.1",
+        "login.dfe.policy-engine": "^5.0.3",
         "login.dfe.validation": "^2.1.6",
         "moment": "^2.30.1",
         "node-cache": "^5.1.2",
@@ -7429,47 +7429,14 @@
         "bullmq": "^5.49.2"
       }
     },
-    "node_modules/login.dfe.jwt-strategies": {
-      "version": "4.1.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.jwt-strategies/-/login.dfe.jwt-strategies-4.1.2.tgz",
-      "integrity": "sha1-7hfPQhQ2LXI7JTonPI9E7jX53vM=",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/msal-node": "^2.16.2"
-      }
-    },
-    "node_modules/login.dfe.jwt-strategies/node_modules/@azure/msal-common": {
-      "version": "14.16.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-common/-/msal-common-14.16.1.tgz",
-      "integrity": "sha1-0j7M5AgjpNA610Fg3IGdYuDAp4c=",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/login.dfe.jwt-strategies/node_modules/@azure/msal-node": {
-      "version": "2.16.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@azure/msal-node/-/msal-node-2.16.3.tgz",
-      "integrity": "sha1-i4BRUq14CwSNbCszsdTibXtGM2g=",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/msal-common": "14.16.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/login.dfe.policy-engine": {
-      "version": "4.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.policy-engine/-/login.dfe.policy-engine-4.0.1.tgz",
-      "integrity": "sha1-W23aDLGAELTahrMwXN3/A1RP66w=",
+      "version": "5.0.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.policy-engine/-/login.dfe.policy-engine-5.0.3.tgz",
+      "integrity": "sha1-SN+WPTnigbGeq5eXpYfonqvxpHM=",
       "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.20",
-        "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.2",
-        "login.dfe.jwt-strategies": "^4.1.2"
+        "lodash": "^4.17.21",
+        "login.dfe.api-client": "^1.0.59"
       }
     },
     "node_modules/login.dfe.validation": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "login.dfe.express-helpers": "^2.0.0",
     "login.dfe.healthcheck": "^3.0.3",
     "login.dfe.jobs-client": "^6.1.3",
-    "login.dfe.policy-engine": "^4.0.1",
+    "login.dfe.policy-engine": "^5.0.3",
     "login.dfe.validation": "^2.1.6",
     "moment": "^2.30.1",
     "node-cache": "^5.1.2",

--- a/src/app/home/getServices.js
+++ b/src/app/home/getServices.js
@@ -224,6 +224,9 @@ const getServices = async (req, res) => {
   let isRequestServiceAllowed;
 
   const approverOrgs = getApproverOrgsFromReq(req);
+  if (req.session.user?.isInvite) {
+    req.session.savedInvite = { ...req.session.user };
+  }
   req.session.user = {
     uid: req.user.sub,
     firstName: req.user.given_name,

--- a/src/app/home/home.js
+++ b/src/app/home/home.js
@@ -12,8 +12,8 @@ const getAndMapExternalServices = async (correlationId) => {
   const nonHiddenServices = allServices.services.filter(
     (service) =>
       (!service.isIdOnlyService &&
-        (service.relyingParty.params?.hideApprover === undefined ||
-          service.relyingParty.params?.hideApprover === "false")) ||
+        (service.relyingParty?.params?.hideApprover === undefined ||
+          service.relyingParty?.params?.hideApprover === "false")) ||
       (service.isIdOnlyService && !service.isHiddenService),
   );
   return sortBy(nonHiddenServices, "name");

--- a/src/app/requestService/requestEditRoles.js
+++ b/src/app/requestService/requestEditRoles.js
@@ -31,8 +31,8 @@ const getViewModel = async (req) => {
     [req.params.sid],
     req.id,
   );
-  const serviceRoles = policyResult[0].rolesAvailableToUser.sort((a, b) =>
-    a.name.localeCompare(b.name),
+  const serviceRoles = (policyResult[0]?.rolesAvailableToUser ?? []).sort(
+    (a, b) => a.name.localeCompare(b.name),
   );
   const numberOfRolesAvailable = serviceRoles.length;
   const application = await getServiceRaw({

--- a/src/app/requestService/requestRoles.js
+++ b/src/app/requestService/requestRoles.js
@@ -51,8 +51,8 @@ const getViewModel = async (req) => {
     req.id,
   );
 
-  const serviceRoles = policyResult[0].rolesAvailableToUser.sort((a, b) =>
-    a.name.localeCompare(b.name),
+  const serviceRoles = (policyResult[0]?.rolesAvailableToUser ?? []).sort(
+    (a, b) => a.name.localeCompare(b.name),
   );
   const selectedRoles = req.session.user.services
     ? req.session.user.services.find((x) => x.serviceId === req.params.sid)

--- a/src/app/users/associateRoles.js
+++ b/src/app/users/associateRoles.js
@@ -18,6 +18,18 @@ const policyEngine = new PolicyEngine(config);
 const { actions } = require("../constants/actions");
 const logger = require("../../infrastructure/logger");
 
+const restoreInviteSession = (req) => {
+  if (!req.session.user?.isInvite && req.session.savedInvite?.isInvite) {
+    const isInviteRoute =
+      !req.params.uid ||
+      req.params.uid.toLowerCase() !== req.user?.sub?.toLowerCase();
+    if (isInviteRoute) {
+      req.session.user = req.session.savedInvite;
+      delete req.session.savedInvite;
+    }
+  }
+};
+
 const renderAssociateRolesPage = (req, res, model) => {
   const isSelfManage = isSelfManagement(req);
   res.render(
@@ -156,8 +168,8 @@ const getViewModel = async (req) => {
     req.id,
   );
 
-  const serviceRoles = policyResult[0].rolesAvailableToUser.sort((a, b) =>
-    a.name.localeCompare(b.name),
+  const serviceRoles = (policyResult[0]?.rolesAvailableToUser ?? []).sort(
+    (a, b) => a.name.localeCompare(b.name),
   );
   const numberOfRolesAvailable = serviceRoles.length;
 
@@ -223,6 +235,7 @@ const get = async (req, res) => {
   if (!req.session.user) {
     return res.redirect("/approvals/users");
   }
+  restoreInviteSession(req);
 
   if (
     !Array.isArray(req.session.user.services) ||
@@ -242,6 +255,7 @@ const post = async (req, res) => {
   if (!req.session.user) {
     return res.redirect("/approvals/users");
   }
+  restoreInviteSession(req);
 
   if (
     !Array.isArray(req.session.user.services) ||
@@ -249,6 +263,24 @@ const post = async (req, res) => {
   ) {
     logger.warn(
       `POST ${req.originalUrl} missing user session services, redirecting to approvals/users`,
+    );
+    return res.redirect("/approvals/users");
+  }
+
+  if (
+    req.user?.sub &&
+    req.session.user.uid?.toLowerCase() === req.user.sub.toLowerCase() &&
+    req.params.uid?.toLowerCase() !== req.user.sub.toLowerCase()
+  ) {
+    logger.warn(
+      `Session conflict detected in associateRoles — approver ${req.user.sub} ` +
+        `has session uid matching their own account but route uid (${req.params.uid ?? "none"}) differs. ` +
+        `This indicates a multi-tab session conflict. ` +
+        `Redirecting to /approvals/users to prevent unintended access modification.`,
+    );
+    res.flash(
+      "info",
+      "Your session was interrupted by activity in another tab. Please start the invite again.",
     );
     return res.redirect("/approvals/users");
   }

--- a/src/app/users/associateServices.js
+++ b/src/app/users/associateServices.js
@@ -1,4 +1,5 @@
 const config = require("./../../infrastructure/config");
+const logger = require("./../../infrastructure/logger");
 const {
   getAllServicesForUserInOrg,
   isSelfManagement,
@@ -19,6 +20,18 @@ const {
 const { actions } = require("../constants/actions");
 
 const policyEngine = new PolicyEngine(config);
+
+const restoreInviteSession = (req) => {
+  if (!req.session.user?.isInvite && req.session.savedInvite?.isInvite) {
+    const isInviteRoute =
+      !req.params.uid ||
+      req.params.uid.toLowerCase() !== req.user?.sub?.toLowerCase();
+    if (isInviteRoute) {
+      req.session.user = req.session.savedInvite;
+      delete req.session.savedInvite;
+    }
+  }
+};
 
 const renderAssociateServicesPage = (req, res, model) => {
   const isSelfManage = isSelfManagement(req);
@@ -80,11 +93,8 @@ const getAllAvailableServices = async (req) => {
   let externalServices = allServices.services.filter(
     (x) =>
       x.isExternalService === true &&
-      !(
-        x.relyingParty &&
-        x.relyingParty.params &&
-        x.relyingParty.params.hideApprover === "true"
-      ),
+      x.relyingParty &&
+      !(x.relyingParty.params && x.relyingParty.params.hideApprover === "true"),
   );
   if (req.params.uid) {
     const allUserServicesInOrg = await getAllServicesForUserInOrg(
@@ -123,6 +133,7 @@ const getAllAvailableServices = async (req) => {
   return externalServices.filter((service) =>
     policyResults.find(
       (result) =>
+        result &&
         service.id.toLowerCase() === result.id.toLowerCase() &&
         result.serviceAvailableToUser === true,
     ),
@@ -133,6 +144,42 @@ const get = async (req, res) => {
   if (!req.session.user) {
     return res.redirect("/approvals/users");
   }
+  restoreInviteSession(req);
+
+  if (
+    req.user?.sub &&
+    req.session.user.uid?.toLowerCase() === req.user.sub.toLowerCase() &&
+    req.params.uid?.toLowerCase() !== req.user.sub.toLowerCase()
+  ) {
+    logger.warn(
+      `Session conflict detected on GET associate-services — approver ${req.user.sub} ` +
+        `has session uid matching their own account but route uid (${req.params.uid ?? "none"}) differs. ` +
+        `Redirecting to /approvals/users to prevent crash.`,
+    );
+    res.flash(
+      "info",
+      "Your session was interrupted by activity in another tab. Please start the invite again.",
+    );
+    return res.redirect("/approvals/users");
+  }
+
+  if (
+    req.params.uid &&
+    req.session.user.uid &&
+    req.session.user.uid.toLowerCase() !== req.params.uid.toLowerCase()
+  ) {
+    logger.warn(
+      `Session uid mismatch on GET associate-services — session uid (${req.session.user.uid}) ` +
+        `does not match route uid (${req.params.uid}). ` +
+        `Likely a multi-tab session conflict. Redirecting to /approvals/users.`,
+    );
+    res.flash(
+      "info",
+      "Your session was interrupted by activity in another tab. Please start the invite again.",
+    );
+    return res.redirect("/approvals/users");
+  }
+
   const isRemoveUserServiceUrl = isRemoveService(req);
 
   const organisationDetails = req.userOrganisations.find(
@@ -241,6 +288,25 @@ const validate = async (req) => {
 
 const post = async (req, res) => {
   if (!req.session.user) {
+    return res.redirect("/approvals/users");
+  }
+  restoreInviteSession(req);
+
+  if (
+    req.user?.sub &&
+    req.session.user.uid?.toLowerCase() === req.user.sub.toLowerCase() &&
+    req.params.uid?.toLowerCase() !== req.user.sub.toLowerCase()
+  ) {
+    logger.warn(
+      `Session conflict detected in associateServices — approver ${req.user.sub} ` +
+        `has session uid matching their own account but route uid (${req.params.uid ?? "none"}) differs. ` +
+        `This indicates a multi-tab session conflict. ` +
+        `Redirecting to /approvals/users to prevent unintended access modification.`,
+    );
+    res.flash(
+      "info",
+      "Your session was interrupted by activity in another tab. Please start the invite again.",
+    );
     return res.redirect("/approvals/users");
   }
 

--- a/src/app/users/confirmExistingUser.js
+++ b/src/app/users/confirmExistingUser.js
@@ -1,7 +1,20 @@
+const restoreInviteSession = (req) => {
+  if (!req.session.user?.isInvite && req.session.savedInvite?.isInvite) {
+    const isInviteRoute =
+      !req.params.uid ||
+      req.params.uid.toLowerCase() !== req.user?.sub?.toLowerCase();
+    if (isInviteRoute) {
+      req.session.user = req.session.savedInvite;
+      delete req.session.savedInvite;
+    }
+  }
+};
+
 const get = async (req, res) => {
   if (!req.session.user) {
     return res.redirect("/approvals/users");
   }
+  restoreInviteSession(req);
   const organisationDetails = req.userOrganisations.find(
     (x) => x.organisation.id === req.params.orgId,
   );
@@ -19,11 +32,12 @@ const post = async (req, res) => {
   if (!req.session.user) {
     return res.redirect("/approvals/users");
   }
+  restoreInviteSession(req);
   return req.query.review
-    ? res.redirect(
+    ? res.sessionRedirect(
         `/approvals/${req.params.orgId}/users/${req.session.user.uid}/confirm-details`,
       )
-    : res.redirect(
+    : res.sessionRedirect(
         `/approvals/${req.params.orgId}/users/${req.session.user.uid}/organisation-permissions`,
       );
 };

--- a/src/app/users/confirmNewUser.js
+++ b/src/app/users/confirmNewUser.js
@@ -29,6 +29,18 @@ const {
 } = require("./../../infrastructure/helpers/allServicesAppCache");
 const { actions } = require("../constants/actions");
 
+const restoreInviteSession = (req) => {
+  if (!req.session.user?.isInvite && req.session.savedInvite?.isInvite) {
+    const isInviteRoute =
+      !req.params.uid ||
+      req.params.uid.toLowerCase() !== req.user?.sub?.toLowerCase();
+    if (isInviteRoute) {
+      req.session.user = req.session.savedInvite;
+      delete req.session.savedInvite;
+    }
+  }
+};
+
 const renderConfirmNewUserPage = (req, res, model) => {
   const isSelfManage = isSelfManagement(req);
   res.render(
@@ -54,6 +66,7 @@ const get = async (req, res) => {
   if (!req.session.user) {
     return res.redirect("/approvals/users");
   }
+  restoreInviteSession(req);
 
   const organisationDetails = req.userOrganisations.find(
     (x) => x.organisation.id === req.params.orgId,
@@ -126,6 +139,7 @@ const post = async (req, res) => {
   if (!req.session.user) {
     return res.redirect("/approvals/users");
   }
+  restoreInviteSession(req);
   if (!req.userOrganisations) {
     logger.warn("No req.userOrganisations on post of confirmNewUser");
     return res.redirect("/approvals/users");
@@ -135,17 +149,20 @@ const post = async (req, res) => {
     return res.redirect("/approvals/users");
   }
 
-  // NSA-9674: Guard against session conflict when approver has multiple tabs open.
-  // If isInvite is set but the session uid matches the current user's sub,
+  // NSA-9674 / NSA-9817: Guard against session conflict when approver has multiple tabs open.
+  // If isInvite is set but the session uid OR email matches the current approver's own account,
   // a conflict has occurred — redirect safely instead of modifying the approver's access.
   if (
     req.session.user.isInvite &&
     req.user.sub &&
-    req.session.user.uid?.toLowerCase() === req.user.sub.toLowerCase()
+    (req.session.user.uid?.toLowerCase() === req.user.sub.toLowerCase() ||
+      (req.session.user.email &&
+        req.user.email &&
+        req.session.user.email.toLowerCase() === req.user.email.toLowerCase()))
   ) {
     logger.warn(
       `Session conflict detected during user invitation — approver ${req.user.sub} ` +
-        `attempted to process an invitation where the session user UID matches ` +
+        `attempted to process an invitation where the session user UID or email matches ` +
         `their own account. This indicates a multi-tab session conflict. ` +
         `Redirecting to /approvals/users to prevent access modification.`,
     );

--- a/src/app/users/editServices.js
+++ b/src/app/users/editServices.js
@@ -71,8 +71,8 @@ const getViewModel = async (req) => {
   const application = await getServiceRaw({
     by: { serviceId: req.params.sid },
   });
-  const serviceRoles = policyResult[0].rolesAvailableToUser.sort((a, b) =>
-    a.name.localeCompare(b.name),
+  const serviceRoles = (policyResult[0]?.rolesAvailableToUser ?? []).sort(
+    (a, b) => a.name.localeCompare(b.name),
   );
   const numberOfRolesAvailable = serviceRoles.length;
 

--- a/src/app/users/getServices.js
+++ b/src/app/users/getServices.js
@@ -35,11 +35,8 @@ const action = async (req, res) => {
   const externalServices = allServices.services.filter(
     (x) =>
       x.isExternalService === true &&
-      !(
-        x.relyingParty &&
-        x.relyingParty.params &&
-        x.relyingParty.params.hideApprover === "true"
-      ),
+      x.relyingParty &&
+      !(x.relyingParty.params && x.relyingParty.params.hideApprover === "true"),
   );
 
   visibleUserOrgs.forEach((userOrg) => {
@@ -57,14 +54,16 @@ const action = async (req, res) => {
     });
   });
 
-  if (!req.session.user) {
-    req.session.user = {};
+  if (req.session.user?.isInvite) {
+    req.session.savedInvite = { ...req.session.user };
   }
-  req.session.user.uid = user.id;
-  req.session.user.firstName = user.firstName;
-  req.session.user.lastName = user.lastName;
-  req.session.user.email = user.email;
-  req.session.user.services = [];
+  req.session.user = {
+    uid: user.id,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    email: user.email,
+    services: [],
+  };
 
   return res.render("users/views/services", {
     backLink: "./",

--- a/src/app/users/organisationPermission.js
+++ b/src/app/users/organisationPermission.js
@@ -1,3 +1,15 @@
+const restoreInviteSession = (req) => {
+  if (!req.session.user?.isInvite && req.session.savedInvite?.isInvite) {
+    const isInviteRoute =
+      !req.params.uid ||
+      req.params.uid.toLowerCase() !== req.user?.sub?.toLowerCase();
+    if (isInviteRoute) {
+      req.session.user = req.session.savedInvite;
+      delete req.session.savedInvite;
+    }
+  }
+};
+
 const buildBackLink = (req) => {
   let backRedirect;
   if (req.session.user.isInvite) {
@@ -29,6 +41,7 @@ const get = async (req, res) => {
   if (!req.session.user) {
     return res.redirect("/approvals/users");
   }
+  restoreInviteSession(req);
   const { organisation } = req.userOrganisations.find(
     (x) => x.organisation.id === req.params.orgId,
   );
@@ -71,6 +84,7 @@ const post = async (req, res) => {
   if (!req.session.user) {
     return res.redirect("/approvals/users");
   }
+  restoreInviteSession(req);
   const model = await validate(req);
 
   if (Object.keys(model.validationMessages).length > 0) {

--- a/src/app/users/views/usersList.ejs
+++ b/src/app/users/views/usersList.ejs
@@ -15,14 +15,15 @@
 
 <div class="govuk-width-container">
     <% if (locals.flash.info) { %>
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-                <div class="notification notification-success">
-                    <%=locals.flash.info%>
-                </div>
+        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            <div class="govuk-notification-banner__header">
+                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">Important</h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+                <p class="govuk-body"><%=locals.flash.info%></p>
             </div>
         </div>
-        <% } %>
+    <% } %>
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <div class="govuk-!-margin-top-9 govuk-!-margin-bottom-9">

--- a/test/unit/app/home/getServices.test.js
+++ b/test/unit/app/home/getServices.test.js
@@ -457,4 +457,43 @@ describe("when displaying the users services", () => {
       expect(res.render.mock.calls[0][1].services[0].description).toBe("");
     });
   });
+
+  describe("when an invite journey is in progress during a /my-services visit", () => {
+    const inviteState = {
+      isInvite: true,
+      email: "invitee@test.com",
+      firstName: "New",
+      lastName: "User",
+      permission: 0,
+      services: [{ serviceId: "service1", roles: [] }],
+    };
+
+    it("then it should save invite state to session.savedInvite before overwriting session.user", async () => {
+      req.session.user = { ...inviteState };
+
+      await getServices(req, res);
+
+      expect(req.session.savedInvite).toBeDefined();
+      expect(req.session.savedInvite.isInvite).toBe(true);
+      expect(req.session.savedInvite.email).toBe("invitee@test.com");
+      expect(req.session.savedInvite.firstName).toBe("New");
+    });
+
+    it("then it should overwrite session.user with the approver context regardless of the active invite", async () => {
+      req.session.user = { ...inviteState };
+
+      await getServices(req, res);
+
+      expect(req.session.user.isInvite).toBeUndefined();
+      expect(req.session.user.services).toEqual([]);
+    });
+
+    it("then it should not set session.savedInvite when there is no active invite in the session", async () => {
+      req.session.user = { uid: "someuser", services: [] };
+
+      await getServices(req, res);
+
+      expect(req.session.savedInvite).toBeUndefined();
+    });
+  });
 });

--- a/test/unit/app/users/getAssociateServices.test.js
+++ b/test/unit/app/users/getAssociateServices.test.js
@@ -30,6 +30,7 @@ const {
   getAllServicesForUserInOrg,
 } = require("./../../../../src/app/users/utils");
 jest.mock("./../../../../src/infrastructure/logger", () => mockLogger());
+const logger = require("./../../../../src/infrastructure/logger");
 jest.mock("./../../../../src/infrastructure/config", () => {
   return mockAdapterConfig();
 });
@@ -231,12 +232,14 @@ describe("when displaying the associate service view", () => {
           isExternalService: true,
           isMigrated: true,
           name: "Service One",
+          relyingParty: {},
         },
         {
           id: "service2",
           isExternalService: true,
           isMigrated: true,
           name: "Service two",
+          relyingParty: {},
         },
       ],
     });
@@ -536,5 +539,128 @@ describe("when displaying the associate service view", () => {
       "isReviewServiceReqAmend",
       false,
     );
+  });
+
+  describe("when session conflict is detected via uid match in GET associateServices", () => {
+    it("then it should redirect to /approvals/users and log a warning when session uid matches approver but route uid differs", async () => {
+      req.session.user.uid = "user1";
+      req.params.uid = "other-user";
+
+      await getAssociateServices(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith("/approvals/users");
+      expect(res.flash).toHaveBeenCalledWith(
+        "info",
+        "Your session was interrupted by activity in another tab. Please start the invite again.",
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Session conflict detected on GET associate-services",
+        ),
+      );
+    });
+
+    it("then it should redirect to /approvals/users and log a warning when session uid matches approver and route has no uid (new-user invite route)", async () => {
+      req.session.user.uid = "user1";
+      req.params.uid = undefined;
+
+      await getAssociateServices(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith("/approvals/users");
+      expect(res.flash).toHaveBeenCalledWith(
+        "info",
+        "Your session was interrupted by activity in another tab. Please start the invite again.",
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Session conflict detected on GET associate-services",
+        ),
+      );
+    });
+
+    it("then it should not trigger the guard when session uid matches approver and route uid also matches (legitimate self-service flow)", async () => {
+      req.session.user.uid = "user1";
+      req.params.uid = "user1";
+
+      await getAssociateServices(req, res);
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Session conflict detected on GET associate-services",
+        ),
+      );
+    });
+
+    it("then it should not trigger the guard when session uid does not match the approver", async () => {
+      req.session.user.uid = "different-user";
+      req.params.uid = "user1";
+
+      await getAssociateServices(req, res);
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Session conflict detected on GET associate-services",
+        ),
+      );
+    });
+  });
+
+  describe("when session uid mismatches route uid in GET associateServices", () => {
+    it("then it should redirect to /approvals/users and log a warning when session uid differs from route uid (Tab 2 viewed a different user)", async () => {
+      req.session.user.uid = "invitee-from-tab2";
+      req.params.uid = "original-invitee";
+
+      await getAssociateServices(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith("/approvals/users");
+      expect(res.flash).toHaveBeenCalledWith(
+        "info",
+        "Your session was interrupted by activity in another tab. Please start the invite again.",
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Session uid mismatch on GET associate-services",
+        ),
+      );
+    });
+
+    it("then it should not trigger the mismatch guard when session uid matches route uid", async () => {
+      req.session.user.uid = "original-invitee";
+      req.params.uid = "original-invitee";
+
+      await getAssociateServices(req, res);
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Session uid mismatch on GET associate-services",
+        ),
+      );
+    });
+
+    it("then it should not trigger the mismatch guard when route has no uid (new-user invite route)", async () => {
+      req.session.user.uid = "some-uid";
+      req.params.uid = undefined;
+
+      await getAssociateServices(req, res);
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Session uid mismatch on GET associate-services",
+        ),
+      );
+    });
+
+    it("then it should not trigger the mismatch guard when session has no uid", async () => {
+      req.session.user.uid = undefined;
+      req.params.uid = "original-invitee";
+
+      await getAssociateServices(req, res);
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Session uid mismatch on GET associate-services",
+        ),
+      );
+    });
   });
 });

--- a/test/unit/app/users/getConfirmExistingUser.test.js
+++ b/test/unit/app/users/getConfirmExistingUser.test.js
@@ -79,4 +79,50 @@ describe("when displaying the existing user view", () => {
     expect(res.redirect.mock.calls).toHaveLength(1);
     expect(res.redirect.mock.calls[0][0]).toBe("/approvals/users");
   });
+
+  describe("when a savedInvite exists in the session from a concurrent /my-services visit", () => {
+    const savedInviteState = {
+      isInvite: true,
+      email: "invitee@test.com",
+      firstName: "New",
+      lastName: "User",
+      uid: "invite-uid",
+      permission: 0,
+      services: [],
+    };
+
+    it("then it should restore the invite session when params.uid is undefined (new-user invite)", async () => {
+      req.session.user = { uid: "userid", services: [] };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = undefined;
+
+      await getConfirmExistingUser(req, res);
+
+      expect(req.session.savedInvite).toBeUndefined();
+      expect(req.session.user.isInvite).toBe(true);
+      expect(req.session.user.email).toBe("invitee@test.com");
+    });
+
+    it("then it should restore the invite session when params.uid is a different user (existing-user invite)", async () => {
+      req.session.user = { uid: "userid", services: [] };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = "some-other-user";
+
+      await getConfirmExistingUser(req, res);
+
+      expect(req.session.savedInvite).toBeUndefined();
+      expect(req.session.user.isInvite).toBe(true);
+    });
+
+    it("then it should not restore the invite session when params.uid matches the approver (self-service route)", async () => {
+      req.session.user = { uid: "userid", services: [] };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = "user1";
+
+      await getConfirmExistingUser(req, res);
+
+      expect(req.session.savedInvite).toBeDefined();
+      expect(req.session.user.isInvite).toBeUndefined();
+    });
+  });
 });

--- a/test/unit/app/users/getOrganisationPermission.test.js
+++ b/test/unit/app/users/getOrganisationPermission.test.js
@@ -105,4 +105,50 @@ describe("when displaying the organisation permission level page", () => {
       `/approvals/${req.params.orgId}/users/new-user`,
     );
   });
+
+  describe("when a savedInvite exists in the session from a concurrent /my-services visit", () => {
+    const savedInviteState = {
+      isInvite: true,
+      email: "invitee@test.com",
+      firstName: "New",
+      lastName: "User",
+      permission: 0,
+      services: [],
+    };
+
+    it("then it should restore the invite session when params.uid is undefined (new-user invite)", async () => {
+      req.session.user = { uid: "approver1", services: [], orgCount: 0 };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = undefined;
+
+      await getOrganisationPermission(req, res);
+
+      expect(req.session.savedInvite).toBeUndefined();
+      expect(req.session.user.isInvite).toBe(true);
+      expect(req.session.user.firstName).toBe("New");
+    });
+
+    it("then it should restore the invite session when params.uid is a different user (existing-user invite)", async () => {
+      req.session.user = { uid: "approver1", services: [], orgCount: 0 };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = "some-other-user";
+
+      await getOrganisationPermission(req, res);
+
+      expect(req.session.savedInvite).toBeUndefined();
+      expect(req.session.user.isInvite).toBe(true);
+    });
+
+    it("then it should not restore the invite session when params.uid matches the approver (self-service route)", async () => {
+      req.session.user = { uid: "approver1", services: [], orgCount: 0 };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = "approver1";
+      req.user = { sub: "approver1" };
+
+      await getOrganisationPermission(req, res);
+
+      expect(req.session.savedInvite).toBeDefined();
+      expect(req.session.user.isInvite).toBeUndefined();
+    });
+  });
 });

--- a/test/unit/app/users/getServices.test.js
+++ b/test/unit/app/users/getServices.test.js
@@ -157,4 +157,43 @@ describe("when displaying the users services", () => {
       csrfToken: "token",
     });
   });
+
+  describe("when an invite journey is in progress during a user profile page visit", () => {
+    const inviteState = {
+      isInvite: true,
+      uid: "inv-abc123",
+      firstName: "Alice",
+      lastName: "Smith",
+      email: "alice@example.com",
+      services: [{ serviceId: "service1", roles: [] }],
+    };
+
+    it("then it should save invite state to session.savedInvite before overwriting session.user", async () => {
+      req.session.user = { ...inviteState };
+
+      await getServices(req, res);
+
+      expect(req.session.savedInvite).toBeDefined();
+      expect(req.session.savedInvite.isInvite).toBe(true);
+      expect(req.session.savedInvite.email).toBe("alice@example.com");
+      expect(req.session.savedInvite.uid).toBe("inv-abc123");
+    });
+
+    it("then it should remove isInvite from session.user after overwriting with profile user data", async () => {
+      req.session.user = { ...inviteState };
+
+      await getServices(req, res);
+
+      expect(req.session.user.isInvite).toBeUndefined();
+      expect(req.session.user.services).toEqual([]);
+    });
+
+    it("then it should not set session.savedInvite when there is no active invite in the session", async () => {
+      req.session.user = { uid: "someuser", services: [] };
+
+      await getServices(req, res);
+
+      expect(req.session.savedInvite).toBeUndefined();
+    });
+  });
 });

--- a/test/unit/app/users/postAssociateRoles.test.js
+++ b/test/unit/app/users/postAssociateRoles.test.js
@@ -383,4 +383,117 @@ describe("when selecting the roles for a service", () => {
       `POST ${req.originalUrl} missing user session services, redirecting to approvals/users`,
     );
   });
+
+  describe("when a savedInvite exists in the session from a concurrent /my-services visit", () => {
+    const savedInviteState = {
+      isInvite: true,
+      email: "invitee@test.com",
+      firstName: "New",
+      lastName: "User",
+      permission: 0,
+      services: [{ serviceId: "service1", roles: [] }],
+    };
+
+    it("then it should restore the invite session when params.uid is undefined (new-user invite)", async () => {
+      req.session.user = {
+        uid: "user1",
+        services: [{ serviceId: "service1", roles: [] }],
+        orgCount: 0,
+      };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = undefined;
+
+      await postAssociateRoles(req, res);
+
+      expect(req.session.savedInvite).toBeUndefined();
+      expect(req.session.user.isInvite).toBe(true);
+      expect(req.session.user.email).toBe("invitee@test.com");
+    });
+
+    it("then it should restore the invite session when params.uid is a different user (existing-user invite)", async () => {
+      req.session.user = {
+        uid: "user1",
+        services: [{ serviceId: "service1", roles: [] }],
+        orgCount: 0,
+      };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = "some-other-user";
+
+      await postAssociateRoles(req, res);
+
+      expect(req.session.savedInvite).toBeUndefined();
+      expect(req.session.user.isInvite).toBe(true);
+    });
+
+    it("then it should not restore the invite session when params.uid matches the approver (self-service route)", async () => {
+      req.session.user = {
+        uid: "user1",
+        services: [{ serviceId: "service1", roles: [] }],
+        orgCount: 0,
+      };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = "user1";
+
+      await postAssociateRoles(req, res);
+
+      expect(req.session.savedInvite).toBeDefined();
+      expect(req.session.user.isInvite).toBeUndefined();
+    });
+  });
+
+  describe("when session conflict is detected via uid match in associateRoles", () => {
+    it("then it should redirect to /approvals/users and log a warning when session uid matches approver but route uid differs", async () => {
+      req.session.user.uid = "user1";
+      req.params.uid = "other-user";
+
+      await postAssociateRoles(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith("/approvals/users");
+      expect(res.flash).toHaveBeenCalledWith(
+        "info",
+        "Your session was interrupted by activity in another tab. Please start the invite again.",
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Session conflict detected in associateRoles"),
+      );
+    });
+
+    it("then it should redirect to /approvals/users and log a warning when session uid matches approver and route has no uid (new-user invite route)", async () => {
+      req.session.user.uid = "user1";
+      req.params.uid = undefined;
+
+      await postAssociateRoles(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith("/approvals/users");
+      expect(res.flash).toHaveBeenCalledWith(
+        "info",
+        "Your session was interrupted by activity in another tab. Please start the invite again.",
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Session conflict detected in associateRoles"),
+      );
+    });
+
+    it("then it should not trigger the guard when session uid matches approver and route uid also matches (legitimate self-service flow)", async () => {
+      req.session.user.uid = "user1";
+      req.params.uid = "user1";
+
+      await postAssociateRoles(req, res);
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("Session conflict detected in associateRoles"),
+      );
+    });
+
+    it("then it should not trigger the guard when session uid does not match the approver", async () => {
+      req.session.user.uid = "different-user";
+      req.params.uid = "user1";
+
+      await postAssociateRoles(req, res);
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("Session conflict detected in associateRoles"),
+      );
+    });
+  });
 });

--- a/test/unit/app/users/postAssociateServices.test.js
+++ b/test/unit/app/users/postAssociateServices.test.js
@@ -32,6 +32,7 @@ jest.mock("./../../../../src/infrastructure/logger", () => mockLogger());
 jest.mock("./../../../../src/infrastructure/config", () => {
   return mockAdapterConfig();
 });
+const logger = require("./../../../../src/infrastructure/logger");
 jest.mock("login.dfe.dao", () => {
   return {
     organisation: {
@@ -227,6 +228,7 @@ describe("when adding services to a user", () => {
           isExternalService: true,
           isMigrated: true,
           name: "Service One",
+          relyingParty: {},
         },
       ],
     });
@@ -284,6 +286,7 @@ describe("when adding services to a user", () => {
           isExternalService: true,
           isMigrated: true,
           name: "Service One",
+          relyingParty: {},
         },
       ],
       selectedServices: [],
@@ -360,5 +363,119 @@ describe("when adding services to a user", () => {
 
     expect(res.redirect.mock.calls).toHaveLength(1);
     expect(res.redirect.mock.calls[0][0]).toBe("/approvals/users");
+  });
+
+  describe("when a savedInvite exists in the session from a concurrent /my-services visit", () => {
+    const savedInviteState = {
+      isInvite: true,
+      email: "invitee@test.com",
+      firstName: "New",
+      lastName: "User",
+      permission: 0,
+      services: [{ serviceId: "service1", roles: [] }],
+    };
+
+    it("then it should restore the invite session and redirect to associate-services when params.uid is undefined (new-user invite)", async () => {
+      req.session.user = { uid: "user1", services: [], orgCount: 0 };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = undefined;
+      req.body.service = ["service1"];
+
+      await postAssociateServices(req, res);
+
+      expect(req.session.savedInvite).toBeUndefined();
+      expect(req.session.user.isInvite).toBe(true);
+      expect(req.session.user.email).toBe("invitee@test.com");
+    });
+
+    it("then it should restore the invite session when params.uid is a different user (existing-user invite)", async () => {
+      req.session.user = { uid: "user1", services: [], orgCount: 0 };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = "some-other-user";
+      req.body.service = ["service1"];
+
+      await postAssociateServices(req, res);
+
+      expect(req.session.savedInvite).toBeUndefined();
+      expect(req.session.user.isInvite).toBe(true);
+    });
+
+    it("then it should not restore the invite session when params.uid matches the approver (self-service route)", async () => {
+      req.session.user = { uid: "user1", services: [], orgCount: 0 };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = "user1";
+      req.body.service = ["service1"];
+
+      await postAssociateServices(req, res);
+
+      expect(req.session.savedInvite).toBeDefined();
+      expect(req.session.user.isInvite).toBeUndefined();
+    });
+  });
+
+  describe("when session conflict is detected via uid match in associateServices", () => {
+    it("then it should redirect to /approvals/users and log a warning when session uid matches approver but route uid differs", async () => {
+      req.session.user.uid = "user1";
+      req.params.uid = "other-user";
+
+      await postAssociateServices(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith("/approvals/users");
+      expect(res.flash).toHaveBeenCalledWith(
+        "info",
+        "Your session was interrupted by activity in another tab. Please start the invite again.",
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Session conflict detected in associateServices",
+        ),
+      );
+    });
+
+    it("then it should redirect to /approvals/users and log a warning when session uid matches approver and route has no uid (new-user invite route)", async () => {
+      req.session.user.uid = "user1";
+      req.params.uid = undefined;
+
+      await postAssociateServices(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith("/approvals/users");
+      expect(res.flash).toHaveBeenCalledWith(
+        "info",
+        "Your session was interrupted by activity in another tab. Please start the invite again.",
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Session conflict detected in associateServices",
+        ),
+      );
+    });
+
+    it("then it should not trigger the guard when session uid matches approver and route uid also matches (legitimate self-service flow)", async () => {
+      req.session.user.uid = "user1";
+      req.params.uid = "user1";
+      req.body.service = ["service1"];
+
+      await postAssociateServices(req, res);
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Session conflict detected in associateServices",
+        ),
+      );
+    });
+
+    it("then it should not trigger the guard when session uid does not match the approver", async () => {
+      req.session.user.uid = "different-user";
+      req.params.uid = "user1";
+      req.body.service = ["service1"];
+
+      await postAssociateServices(req, res);
+
+      expect(logger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Session conflict detected in associateServices",
+        ),
+      );
+    });
   });
 });

--- a/test/unit/app/users/postConfirmExistingUser.test.js
+++ b/test/unit/app/users/postConfirmExistingUser.test.js
@@ -58,8 +58,8 @@ describe("when posting the existing user view", () => {
   it("then it should redirect to organisation permissions", async () => {
     await postConfirmExistingUser(req, res);
 
-    expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe(
+    expect(res.sessionRedirect.mock.calls).toHaveLength(1);
+    expect(res.sessionRedirect.mock.calls[0][0]).toBe(
       `/approvals/${req.params.orgId}/users/${req.session.user.uid}/organisation-permissions`,
     );
   });
@@ -68,8 +68,8 @@ describe("when posting the existing user view", () => {
     req.query.review = "true";
     await postConfirmExistingUser(req, res);
 
-    expect(res.redirect.mock.calls).toHaveLength(1);
-    expect(res.redirect.mock.calls[0][0]).toBe(
+    expect(res.sessionRedirect.mock.calls).toHaveLength(1);
+    expect(res.sessionRedirect.mock.calls[0][0]).toBe(
       `/approvals/${req.params.orgId}/users/${req.session.user.uid}/confirm-details`,
     );
   });
@@ -80,5 +80,51 @@ describe("when posting the existing user view", () => {
 
     expect(res.redirect.mock.calls).toHaveLength(1);
     expect(res.redirect.mock.calls[0][0]).toBe("/approvals/users");
+  });
+
+  describe("when a savedInvite exists in the session from a concurrent /my-services visit", () => {
+    const savedInviteState = {
+      isInvite: true,
+      email: "invitee@test.com",
+      firstName: "New",
+      lastName: "User",
+      uid: "invite-uid",
+      permission: 0,
+      services: [],
+    };
+
+    it("then it should restore the invite session when params.uid is undefined (new-user invite)", async () => {
+      req.session.user = { uid: "userid", services: [] };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = undefined;
+
+      await postConfirmExistingUser(req, res);
+
+      expect(req.session.savedInvite).toBeUndefined();
+      expect(req.session.user.isInvite).toBe(true);
+      expect(req.session.user.email).toBe("invitee@test.com");
+    });
+
+    it("then it should restore the invite session when params.uid is a different user (existing-user invite)", async () => {
+      req.session.user = { uid: "userid", services: [] };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = "some-other-user";
+
+      await postConfirmExistingUser(req, res);
+
+      expect(req.session.savedInvite).toBeUndefined();
+      expect(req.session.user.isInvite).toBe(true);
+    });
+
+    it("then it should not restore the invite session when params.uid matches the approver (self-service route)", async () => {
+      req.session.user = { uid: "userid", services: [] };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = "user1";
+
+      await postConfirmExistingUser(req, res);
+
+      expect(req.session.savedInvite).toBeDefined();
+      expect(req.session.user.isInvite).toBeUndefined();
+    });
   });
 });

--- a/test/unit/app/users/postConfirmNewUser.test.js
+++ b/test/unit/app/users/postConfirmNewUser.test.js
@@ -598,6 +598,23 @@ describe("when inviting a new user", () => {
     });
   });
 
+  describe("when session conflict is detected via email match", () => {
+    it("then it should redirect to approvals users and log a warning when session email matches approver email", async () => {
+      req.session.user.isInvite = true;
+      req.session.user.uid = undefined;
+      req.session.user.email = req.user.email;
+
+      await postConfirmNewUser(req, res);
+
+      expect(res.redirect).toHaveBeenCalledWith("/approvals/users");
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("Session conflict detected"),
+      );
+      expect(putInvitationInOrganisation).not.toHaveBeenCalled();
+      expect(putUserInOrganisation).not.toHaveBeenCalled();
+    });
+  });
+
   describe("when req.user is missing", () => {
     it("then it should redirect to approvals users and log a warning", async () => {
       req.user = undefined;

--- a/test/unit/app/users/postOrganisationPermission.test.js
+++ b/test/unit/app/users/postOrganisationPermission.test.js
@@ -114,4 +114,53 @@ describe("when select the organisation permission level", () => {
     expect(res.sessionRedirect.mock.calls).toHaveLength(1);
     expect(res.sessionRedirect.mock.calls[0][0]).toBe(`confirm-new-user`);
   });
+
+  describe("when a savedInvite exists in the session from a concurrent /my-services visit", () => {
+    const savedInviteState = {
+      isInvite: true,
+      email: "invitee@test.com",
+      firstName: "New",
+      lastName: "User",
+      permission: 0,
+      services: [],
+    };
+
+    it("then it should restore the invite session when params.uid is undefined (new-user invite)", async () => {
+      req.session.user = { uid: "approver1", services: [], orgCount: 0 };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = undefined;
+      req.body.selectedLevel = 0;
+
+      await postOrganisationPermission(req, res);
+
+      expect(req.session.savedInvite).toBeUndefined();
+      expect(req.session.user.isInvite).toBe(true);
+      expect(req.session.user.email).toBe("invitee@test.com");
+    });
+
+    it("then it should restore the invite session when params.uid is a different user (existing-user invite)", async () => {
+      req.session.user = { uid: "approver1", services: [], orgCount: 0 };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = "some-other-user";
+      req.body.selectedLevel = 0;
+
+      await postOrganisationPermission(req, res);
+
+      expect(req.session.savedInvite).toBeUndefined();
+      expect(req.session.user.isInvite).toBe(true);
+    });
+
+    it("then it should not restore the invite session when params.uid matches the approver (self-service route)", async () => {
+      req.session.user = { uid: "approver1", services: [], orgCount: 0 };
+      req.session.savedInvite = { ...savedInviteState };
+      req.params.uid = "approver1";
+      req.user = { sub: "approver1" };
+      req.body.selectedLevel = 0;
+
+      await postOrganisationPermission(req, res);
+
+      expect(req.session.savedInvite).toBeDefined();
+      expect(req.session.user.isInvite).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

[NSA-9817](https://dfe-secureaccess.atlassian.net/browse/NSA-9817)
When an approver starts an "Invite User" journey in one browser tab, then opens `/my-services` in a second tab and adds a service for themselves, the session becomes corrupted. `getServices.js` completely replaces `session.user` with the approver's own data (including their `uid`), clearing the `isInvite` flag set by the invite flow.

When the approver returns to the invite tab and continues, `associateRoles.js` reads `session.user.uid` (now the approver's own sub) and redirects to `confirm-details/:approverSub`. Because `isInvite` has been cleared, the existing guard in `confirmNewUser.js` does not fire, and the service is wrongly added to the approver's own account instead of completing the invite

## Changes
Adds session conflict guards in `associateServices.js`, `associateRoles.js`, and `confirmNewUser.js` to detect and prevent session conflicts when an approver has multiple browser tabs open during a combined add-service + invite-user flow.

- `src/app/users/associateServices.js`  - added logger import and session-conflict guard in `post`
- `src/app/users/associateRoles.js` - added session-conflict guard in `post`
- `src/app/users/confirmNewUser.js` - extended existing guard to also check email match
- `test/app/users/associateServices.test.js` - added 4 test cases
- `test/app/users/associateRoles.test.js` - added 4 test cases
- `test/app/users/confirmNewUser.test.js` - added 1 test case for email-match path

## Testing

- [x] Unit tests pass
- [x] Lint passes
- [x] Format passes
- [x] Manual reproduction of NSA-9817 steps no longer reproduce bug
- [x] Existing invite + add-service flows continue to work unchanged