### PR TITLE
NSA-8951: Remove status from putUserInOrganisation and callers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "he": "^1.2.0",
         "helmet": "^7.2.0",
         "lodash": "^4.17.21",
-        "login.dfe.api-client": "^1.0.63",
+        "login.dfe.api-client": "^1.0.69",
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
         "login.dfe.audit.transporter": "^4.0.4",
         "login.dfe.config.schema.common": "^2.1.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,11 +22,11 @@
         "he": "^1.2.0",
         "helmet": "^7.2.0",
         "lodash": "^4.17.21",
-        "login.dfe.api-client": "^1.0.58",
+        "login.dfe.api-client": "^1.0.63",
         "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
         "login.dfe.audit.transporter": "^4.0.4",
         "login.dfe.config.schema.common": "^2.1.8",
-        "login.dfe.dao": "^5.0.6",
+        "login.dfe.dao": "^5.0.7",
         "login.dfe.express-flash-2": "github:DFE-Digital/login.dfe.express-flash-2#v2.0.1",
         "login.dfe.express-helpers": "^2.0.0",
         "login.dfe.healthcheck": "^3.0.3",
@@ -7352,9 +7352,9 @@
       }
     },
     "node_modules/login.dfe.dao": {
-      "version": "5.0.6",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.dao/-/login.dfe.dao-5.0.6.tgz",
-      "integrity": "sha1-bwk7ASTuXw1/Rb8QmiSLQgQ7FIk=",
+      "version": "5.0.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.dao/-/login.dfe.dao-5.0.7.tgz",
+      "integrity": "sha1-2d28ey6pNzJiqHiXfmwancZouRA=",
       "license": "ISC",
       "dependencies": {
         "express": "^4.17.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7296,9 +7296,9 @@
       "license": "MIT"
     },
     "node_modules/login.dfe.api-client": {
-      "version": "1.0.63",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.63.tgz",
-      "integrity": "sha1-B+9RuvLcAbQUywyRL+gDROyLiVg=",
+      "version": "1.0.69",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/login.dfe.api-client/-/login.dfe.api-client-1.0.69.tgz",
+      "integrity": "sha1-AHNFlmxl5DgYgGFnNm4zVHdbItA=",
       "dependencies": {
         "@azure/msal-node": "^3.1.0",
         "applicationinsights": "^2.9.6",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.transporter": "^4.0.4",
     "login.dfe.config.schema.common": "^2.1.8",
-    "login.dfe.dao": "^5.0.6",
+    "login.dfe.dao": "^5.0.7",
     "login.dfe.express-flash-2": "github:DFE-Digital/login.dfe.express-flash-2#v2.0.1",
     "login.dfe.express-helpers": "^2.0.0",
     "login.dfe.healthcheck": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "he": "^1.2.0",
     "helmet": "^7.2.0",
     "lodash": "^4.17.21",
-    "login.dfe.api-client": "^1.0.63",
+    "login.dfe.api-client": "^1.0.69",
     "login.dfe.async-retry": "github:DFE-Digital/login.dfe.async-retry#v2.0.3",
     "login.dfe.audit.transporter": "^4.0.4",
     "login.dfe.config.schema.common": "^2.1.8",

--- a/src/app/accessRequests/reviewOrganisationRequest.js
+++ b/src/app/accessRequests/reviewOrganisationRequest.js
@@ -86,7 +86,6 @@ const post = async (req, res) => {
   await putUserInOrganisation(
     model.request.user_id,
     model.request.org_id,
-    0,
     null,
     correlationId,
   );

--- a/src/app/users/confirmNewUser.js
+++ b/src/app/users/confirmNewUser.js
@@ -204,7 +204,6 @@ const post = async (req, res) => {
       await putUserInOrganisation(
         uid,
         organisationId,
-        0,
         req.session.user.permission,
         req.id,
       );

--- a/src/app/users/editPermission.js
+++ b/src/app/users/editPermission.js
@@ -55,7 +55,7 @@ const post = async (req, res) => {
   } else {
     const mngUserOrganisations = await getOrganisationAndServiceForUser(uid);
 
-    await putUserInOrganisation(uid, organisationId, 1, roleId, req.id);
+    await putUserInOrganisation(uid, organisationId, roleId, req.id);
     if (isEmailAllowed) {
       const mngUserOrganisationDetails = mngUserOrganisations.find(
         (x) => x.organisation.id === organisationId,

--- a/src/infrastructure/organisations/api.js
+++ b/src/infrastructure/organisations/api.js
@@ -4,12 +4,11 @@ const getOrganisationAndServiceForUser = async (userId) => {
   return await organisation.getOrganisationsForUserIncludingServices(userId);
 };
 
-const putUserInOrganisation = async (userId, orgId, status, role, reason) => {
+const putUserInOrganisation = async (userId, orgId, role, reason) => {
   const userOrg = {
     user_id: userId,
     organisation_id: orgId,
     role_id: role,
-    status,
     reason,
   };
   return organisation.putUserOrganisation(userOrg);

--- a/test/unit/app/accessRequests/reviewOrganisationRequest.post.test.js
+++ b/test/unit/app/accessRequests/reviewOrganisationRequest.post.test.js
@@ -230,9 +230,8 @@ describe("when reviewing an organisation request", () => {
     expect(putUserInOrganisation.mock.calls).toHaveLength(1);
     expect(putUserInOrganisation.mock.calls[0][0]).toBe("userId");
     expect(putUserInOrganisation.mock.calls[0][1]).toBe("org1");
-    expect(putUserInOrganisation.mock.calls[0][2]).toBe(0);
-    expect(putUserInOrganisation.mock.calls[0][3]).toBe(null);
-    expect(putUserInOrganisation.mock.calls[0][4]).toBe("correlationId");
+    expect(putUserInOrganisation.mock.calls[0][2]).toBe(null);
+    expect(putUserInOrganisation.mock.calls[0][3]).toBe("correlationId");
 
     expect(updateRequestById.mock.calls).toHaveLength(1);
     expect(updateRequestById.mock.calls[0][0]).toBe("requestId");

--- a/test/unit/app/users/postConfirmNewUser.test.js
+++ b/test/unit/app/users/postConfirmNewUser.test.js
@@ -355,8 +355,7 @@ describe("when inviting a new user", () => {
     expect(putUserInOrganisation.mock.calls[0][0]).toBe("user1");
     expect(putUserInOrganisation.mock.calls[0][1]).toBe("org1");
     expect(putUserInOrganisation.mock.calls[0][2]).toBe(0);
-    expect(putUserInOrganisation.mock.calls[0][3]).toBe(0);
-    expect(putUserInOrganisation.mock.calls[0][4]).toBe("correlationId");
+    expect(putUserInOrganisation.mock.calls[0][3]).toBe("correlationId");
   });
 
   it("then it should not attempt to add user to organisation if not through invite journey", async () => {

--- a/test/unit/infrastructure/organisations/OrganisationsApi.putUsersInOrganisation.spec.js
+++ b/test/unit/infrastructure/organisations/OrganisationsApi.putUsersInOrganisation.spec.js
@@ -43,7 +43,6 @@ jest.mock("login.dfe.dao", () => {
                 user_id: "11D62132-6570-4E63-9DCB-137CC35E7543",
                 organisation_id: "1148F925-D0FB-4A3D-A0C8-D0EC96F1AE69",
                 role_id: 10000,
-                status: 0,
                 reason: null,
                 numeric_identifier: null,
                 text_identifier: null,
@@ -54,7 +53,6 @@ jest.mock("login.dfe.dao", () => {
                 user_id: "E15CCDE2-FFDC-4593-8475-3759C0F86FFD",
                 organisation_id: "1148F925-D0FB-4A3D-A0C8-D0EC96F1AE69",
                 role_id: 10000,
-                status: 0,
                 reason: null,
                 numeric_identifier: "147",
                 text_identifier: "h73ndef",
@@ -65,7 +63,6 @@ jest.mock("login.dfe.dao", () => {
                 user_id: "C844FCBD-ECCF-485D-B6E1-72A1E7D924E1",
                 organisation_id: "1148F925-D0FB-4A3D-A0C8-D0EC96F1AE69",
                 role_id: 10000,
-                status: 1,
                 reason: "05b14b8c-0716-4eeb-b913-894196f13d78",
                 numeric_identifier: "131",
                 text_identifier: "hkhedd4",
@@ -76,7 +73,6 @@ jest.mock("login.dfe.dao", () => {
                 user_id: "20A11600-DEDD-4929-AE21-858868C85D26",
                 organisation_id: "1148F925-D0FB-4A3D-A0C8-D0EC96F1AE69",
                 role_id: 10000,
-                status: 1,
                 reason: null,
                 numeric_identifier: "29",
                 text_identifier: "r6ffe4f",
@@ -87,7 +83,6 @@ jest.mock("login.dfe.dao", () => {
                 user_id: "2F0E3A37-1BD8-450A-9001-860079E2778F",
                 organisation_id: "1148F925-D0FB-4A3D-A0C8-D0EC96F1AE69",
                 role_id: 10000,
-                status: 1,
                 reason: "db2afee7-2ea2-4a09-822a-89b2ea893ac6",
                 numeric_identifier: "136",
                 text_identifier: "hkkf4ff",
@@ -98,7 +93,6 @@ jest.mock("login.dfe.dao", () => {
                 user_id: "4BFE4D49-7DE8-489C-9321-BDDA0D2C4D1C",
                 organisation_id: "1148F925-D0FB-4A3D-A0C8-D0EC96F1AE69",
                 role_id: 10000,
-                status: 0,
                 reason: "2a44817f-eb15-4fdb-a363-876427f7b4a8",
                 numeric_identifier: "262",
                 text_identifier: "r2r4fe4",
@@ -109,7 +103,6 @@ jest.mock("login.dfe.dao", () => {
                 user_id: "C7AE5F34-33EE-4148-A160-E09F029AC5BB",
                 organisation_id: "1148F925-D0FB-4A3D-A0C8-D0EC96F1AE69",
                 role_id: 10000,
-                status: 0,
                 reason: null,
                 numeric_identifier: "148",
                 text_identifier: "h774nde",
@@ -120,7 +113,6 @@ jest.mock("login.dfe.dao", () => {
                 user_id: "26F2F3C3-B367-4027-995B-F5EFAF21985A",
                 organisation_id: "1148F925-D0FB-4A3D-A0C8-D0EC96F1AE69",
                 role_id: 10000,
-                status: 1,
                 reason: "",
                 numeric_identifier: null,
                 text_identifier: null,
@@ -162,7 +154,6 @@ describe("when putting a user in organisations for approval", () => {
     await apiCall.putUserInOrganisation(
       "user1",
       "org1",
-      "status1",
       "role1",
       "rejection-reason",
       "correlationId",
@@ -170,9 +161,6 @@ describe("when putting a user in organisations for approval", () => {
     expect(dao.organisation.putUserOrganisation.mock.calls).toHaveLength(1);
     expect(dao.organisation.putUserOrganisation.mock.calls[0][0].reason).toBe(
       "rejection-reason",
-    );
-    expect(dao.organisation.putUserOrganisation.mock.calls[0][0].status).toBe(
-      "status1",
     );
     expect(dao.organisation.putUserOrganisation.mock.calls[0][0].role_id).toBe(
       "role1",


### PR DESCRIPTION
## Summary

- Removes `status` parameter from `putUserInOrganisation` in `src/infrastructure/organisations/api.js`
- Removes `status` argument from 3 call sites: `editPermission.js`, `confirmNewUser.js`, `reviewOrganisationRequest.js`
- Updates all related tests (positional arg assertions, fixture data)

## Context

The `status` argument was always passed as a hardcoded `0` or `1` and stored in a column that was never read. Part of NSA-8951.

## Test plan

- [ ] AC1, AC4, AC5, AC6 from NSA-8951 Jira ticket
- [ ] Confirm new user via invite flow — user added to organisation correctly
- [ ] Edit user permission level — role updated, no errors
- [ ] Approve organisation access request via Services portal — user added correctly
- [ ] All 668 unit tests passing
