### PR TITLE
Feature/nsa 9688 computed visibility

### DIFF
--- a/src/app/home/home.js
+++ b/src/app/home/home.js
@@ -8,13 +8,8 @@ const {
 const getAndMapExternalServices = async (correlationId) => {
   const allServices = await checkCacheForAllServices(correlationId);
 
-  // Note, we're not checking `isHiddenService` for a non-id-only service.
   const nonHiddenServices = allServices.services.filter(
-    (service) =>
-      (!service.isIdOnlyService &&
-        (service.relyingParty?.params?.hideApprover === undefined ||
-          service.relyingParty?.params?.hideApprover === "false")) ||
-      (service.isIdOnlyService && !service.isHiddenService),
+    (service) => !service.isHiddenForApprover,
   );
   return sortBy(nonHiddenServices, "name");
 };

--- a/src/app/requestService/requestService.js
+++ b/src/app/requestService/requestService.js
@@ -35,13 +35,7 @@ const buildBackLink = (req) => {
 const getAllAvailableServices = async (req) => {
   const allServices = await checkCacheForAllServices(req.id);
   let externalServices = allServices.services.filter(
-    (x) =>
-      x.isExternalService === true &&
-      !(
-        x.relyingParty &&
-        x.relyingParty.params &&
-        x.relyingParty.params.hideApprover === "true"
-      ),
+    (x) => x.isExternalService === true && !x.isHiddenForApprover,
   );
   if (req.params.uid) {
     const allUserServicesInOrg = await getAllServicesForUserInOrg(

--- a/src/app/users/associateServices.js
+++ b/src/app/users/associateServices.js
@@ -92,10 +92,7 @@ const getAllAvailableServices = async (req) => {
 
   const allServices = await checkCacheForAllServices(req.id);
   let externalServices = allServices.services.filter(
-    (x) =>
-      x.isExternalService === true &&
-      x.relyingParty &&
-      !(x.relyingParty.params && x.relyingParty.params.hideApprover === "true"),
+    (x) => x.isExternalService === true && !x.isHiddenForApprover,
   );
   if (req.params.uid) {
     const allUserServicesInOrg = await getAllServicesForUserInOrg(

--- a/src/app/users/getServices.js
+++ b/src/app/users/getServices.js
@@ -33,10 +33,7 @@ const action = async (req, res) => {
   // prepare details for all services to start matching and building details for the view
   const allServices = await checkCacheForAllServices();
   const externalServices = allServices.services.filter(
-    (x) =>
-      x.isExternalService === true &&
-      x.relyingParty &&
-      !(x.relyingParty.params && x.relyingParty.params.hideApprover === "true"),
+    (x) => x.isExternalService === true && !x.isHiddenForApprover,
   );
 
   visibleUserOrgs.forEach((userOrg) => {

--- a/src/app/users/selectServiceWithOrganisation.js
+++ b/src/app/users/selectServiceWithOrganisation.js
@@ -52,32 +52,28 @@ const filterHiddenOrganisations = (serviceOrganisations) => {
 };
 
 const listVisibleServiceOrganisations = async (req) => {
-  try {
-    const isRemoveRequest = isRemoveService(req);
-    const filterByApproverRole = isRemoveRequest ? true : false;
+  const isRemoveRequest = isRemoveService(req);
+  const filterByApproverRole = isRemoveRequest ? true : false;
 
-    const allServiceOrganisations =
-      await services.getFilteredUserServicesWithOrganisation(
-        req.user.sub,
-        filterByApproverRole,
-      );
-
-    const allCachedServices = await checkCacheForAllServices();
-    const hiddenServiceIds = new Set(
-      (allCachedServices?.services ?? [])
-        .filter((s) => s.isHiddenForApprover)
-        .map((s) => s.id),
+  const allServiceOrganisations =
+    await services.getFilteredUserServicesWithOrganisation(
+      req.user.sub,
+      filterByApproverRole,
     );
 
-    // filter services associated with hidden organisations and NSA-9688 hidden services
-    const serviceOrganisations = filterHiddenOrganisations(
-      allServiceOrganisations,
-    ).filter((so) => !hiddenServiceIds.has(so.Service.id));
+  const allCachedServices = await checkCacheForAllServices();
+  const hiddenServiceIds = new Set(
+    (allCachedServices?.services ?? [])
+      .filter((s) => s.isHiddenForApprover)
+      .map((s) => s.id),
+  );
 
-    return buildAdditionalOrgDetails(serviceOrganisations);
-  } catch (error) {
-    throw error;
-  }
+  // filter services associated with hidden organisations and NSA-9688 hidden services
+  const serviceOrganisations = filterHiddenOrganisations(
+    allServiceOrganisations,
+  ).filter((so) => !hiddenServiceIds.has(so.Service.id));
+
+  return buildAdditionalOrgDetails(serviceOrganisations);
 };
 
 const get = async (req, res) => {

--- a/src/app/users/selectServiceWithOrganisation.js
+++ b/src/app/users/selectServiceWithOrganisation.js
@@ -1,5 +1,8 @@
 const { services, organisation } = require("login.dfe.dao");
 const {
+  checkCacheForAllServices,
+} = require("../../infrastructure/helpers/allServicesAppCache");
+const {
   getOrgNaturalIdentifiers,
   isRemoveService,
   isOrgEndUser,
@@ -53,17 +56,24 @@ const listVisibleServiceOrganisations = async (req) => {
     const isRemoveRequest = isRemoveService(req);
     const filterByApproverRole = isRemoveRequest ? true : false;
 
-    // get visible service for all orgs for this user: checking isExternalService, hideApprover
     const allServiceOrganisations =
       await services.getFilteredUserServicesWithOrganisation(
         req.user.sub,
         filterByApproverRole,
       );
 
-    // filter services associated with hidden oranisations (ID only services)
+    const allCachedServices = await checkCacheForAllServices();
+    const hiddenServiceIds = new Set(
+      (allCachedServices?.services ?? [])
+        .filter((s) => s.isHiddenForApprover)
+        .map((s) => s.id),
+    );
+
+    // filter services associated with hidden organisations and NSA-9688 hidden services
     const serviceOrganisations = filterHiddenOrganisations(
       allServiceOrganisations,
-    );
+    ).filter((so) => !hiddenServiceIds.has(so.Service.id));
+
     return buildAdditionalOrgDetails(serviceOrganisations);
   } catch (error) {
     throw new Error(error);

--- a/src/app/users/selectServiceWithOrganisation.js
+++ b/src/app/users/selectServiceWithOrganisation.js
@@ -76,7 +76,7 @@ const listVisibleServiceOrganisations = async (req) => {
 
     return buildAdditionalOrgDetails(serviceOrganisations);
   } catch (error) {
-    throw new Error(error);
+    throw error;
   }
 };
 

--- a/src/infrastructure/applications/api.js
+++ b/src/infrastructure/applications/api.js
@@ -1,5 +1,5 @@
 const { services } = require("login.dfe.dao");
-const { getPaginatedServices } = require("login.dfe.api-client/services");
+const { getPaginatedServicesRaw } = require("login.dfe.api-client/services");
 
 const getAllServices = async () => {
   const services = [];
@@ -7,10 +7,10 @@ const getAllServices = async () => {
   let pageNumber = 1;
   let numberOfPages = undefined;
   while (numberOfPages === undefined || pageNumber <= numberOfPages) {
-    const result = await getPaginatedServices({ pageSize: 50, pageNumber });
+    const result = await getPaginatedServicesRaw({ pageSize: 50, pageNumber });
     services.push(...result.services);
 
-    numberOfPages = result.totalNumberOfPages;
+    numberOfPages = result.numberOfPages;
     pageNumber += 1;
   }
 

--- a/test/unit/app/home/home.test.js
+++ b/test/unit/app/home/home.test.js
@@ -27,21 +27,17 @@ jest.mock("../../../../src/infrastructure/helpers/allServicesAppCache", () => {
 });
 jest.mock("./../../../../src/infrastructure/logger", () => mockLogger());
 
-const createService = (id, name, hideApprover = "false") => {
+const createService = (id, name, isHiddenForApprover = false) => {
   return {
     id,
     name,
     description: "service description",
     isExternalService: true,
     isMigrated: true,
-    isHiddenService: false,
-    isIdOnlyService: false,
+    isHiddenForApprover,
     relyingParty: {
       service_home: "http://service.one/login",
       redirect_uris: ["http://service.one/login/cb"],
-      params: {
-        hideApprover,
-      },
     },
   };
 };
@@ -77,53 +73,9 @@ describe("when displaying current organisation and service mapping", () => {
 
   it("then it should include non-hidden services in the model", async () => {
     const services = [
-      createService("service-1", "1 - Visible role-based service one"),
-      {
-        id: "service-2",
-        name: "2 - Visible ID-only service two",
-        description: "service description",
-        isExternalService: true,
-        isMigrated: true,
-        isHiddenService: false,
-        isIdOnlyService: true,
-        relyingParty: {
-          service_home: "http://service.two/login",
-          redirect_uris: ["http://service.two/login/cb"],
-          params: {
-            hideApprover: "true",
-          },
-        },
-      },
-      {
-        id: "service-3",
-        name: "3 - Visible param-less role-based service three",
-        description: "service description",
-        isExternalService: true,
-        isMigrated: true,
-        isHiddenService: false,
-        isIdOnlyService: false,
-        relyingParty: {
-          service_home: "http://service.three/login",
-          redirect_uris: ["http://service.three/login/cb"],
-        },
-      },
-      createService("service-4", "4 - Hidden role-based service four", "true"),
-      {
-        id: "service-5",
-        name: "5 - Hidden ID-only service five",
-        description: "service description",
-        isExternalService: true,
-        isMigrated: true,
-        isHiddenService: true,
-        isIdOnlyService: true,
-        relyingParty: {
-          service_home: "http://service.five/login",
-          redirect_uris: ["http://service.five/login/cb"],
-          params: {
-            hideApprover: "true",
-          },
-        },
-      },
+      createService("service-1", "1 - Visible service one", false),
+      createService("service-2", "2 - Visible service two", false),
+      createService("service-3", "3 - Hidden service three", true),
     ];
     checkCacheForAllServices.mockResolvedValue({
       services,
@@ -136,8 +88,31 @@ describe("when displaying current organisation and service mapping", () => {
     expect(res.render.mock.calls[0][1].services).toEqual([
       services[0],
       services[1],
-      services[2],
     ]);
+  });
+
+  it("should exclude a service with isHiddenForApprover: true", async () => {
+    const services = [
+      createService("service-visible", "Visible Service", false),
+      createService("service-hidden", "Hidden Service", true),
+    ];
+    checkCacheForAllServices.mockResolvedValue({ services });
+
+    await home(req, res);
+
+    const rendered = res.render.mock.calls[0][1].services;
+    expect(rendered.map((s) => s.id)).not.toContain("service-hidden");
+    expect(rendered.map((s) => s.id)).toContain("service-visible");
+  });
+
+  it("should include a service with isHiddenForApprover: false", async () => {
+    const services = [createService("service-shown", "Shown Service", false)];
+    checkCacheForAllServices.mockResolvedValue({ services });
+
+    await home(req, res);
+
+    const rendered = res.render.mock.calls[0][1].services;
+    expect(rendered.map((s) => s.id)).toContain("service-shown");
   });
 
   it("then it should include title in model", async () => {

--- a/test/unit/app/requestService/requestService.get.test.js
+++ b/test/unit/app/requestService/requestService.get.test.js
@@ -104,12 +104,14 @@ describe("when displaying the request a service page", () => {
         {
           id: "service1",
           isExternalService: true,
+          isHiddenForApprover: false,
           isMigrated: true,
           name: "Service One",
         },
         {
           id: "service2",
           isExternalService: true,
+          isHiddenForApprover: false,
           isMigrated: true,
           name: "Service two",
         },
@@ -164,5 +166,70 @@ describe("when displaying the request a service page", () => {
     expect(res.render.mock.calls[0][1]).toMatchObject({
       csrfToken: "token",
     });
+  });
+
+  it("should exclude a service with isHiddenForApprover: true from results", async () => {
+    checkCacheForAllServices.mockReturnValue({
+      services: [
+        {
+          id: "service-visible",
+          isExternalService: true,
+          isHiddenForApprover: false,
+          isMigrated: true,
+          name: "Visible Service",
+        },
+        {
+          id: "service-hidden",
+          isExternalService: true,
+          isHiddenForApprover: true,
+          isMigrated: true,
+          name: "Hidden Service",
+        },
+      ],
+    });
+    getAllServicesForUserInOrg.mockReturnValue([]);
+    policyEngine.getPolicyApplicationResultsForUser.mockImplementation(
+      (userId, organisationId, serviceIds) =>
+        serviceIds.map((id) => ({
+          id,
+          policiesAppliedForUser: [],
+          rolesAvailableToUser: [],
+          serviceAvailableToUser: true,
+        })),
+    );
+
+    await get(req, res);
+
+    const services = res.render.mock.calls[0][1].services;
+    expect(services.map((s) => s.id)).not.toContain("service-hidden");
+    expect(services.map((s) => s.id)).toContain("service-visible");
+  });
+
+  it("should include a service with isHiddenForApprover: false in results", async () => {
+    checkCacheForAllServices.mockReturnValue({
+      services: [
+        {
+          id: "service-shown",
+          isExternalService: true,
+          isHiddenForApprover: false,
+          isMigrated: true,
+          name: "Shown Service",
+        },
+      ],
+    });
+    getAllServicesForUserInOrg.mockReturnValue([]);
+    policyEngine.getPolicyApplicationResultsForUser.mockReturnValue([
+      {
+        id: "service-shown",
+        policiesAppliedForUser: [],
+        rolesAvailableToUser: [],
+        serviceAvailableToUser: true,
+      },
+    ]);
+
+    await get(req, res);
+
+    const services = res.render.mock.calls[0][1].services;
+    expect(services.map((s) => s.id)).toContain("service-shown");
   });
 });

--- a/test/unit/app/users/getAssociateServices.test.js
+++ b/test/unit/app/users/getAssociateServices.test.js
@@ -27,9 +27,6 @@ const {
   mockAdapterConfig,
 } = require("./../../../utils/jestMocks");
 const {
-  getAllServices,
-} = require("./../../../../src/infrastructure/applications");
-const {
   getAllServicesForUserInOrg,
 } = require("./../../../../src/app/users/utils");
 jest.mock("./../../../../src/infrastructure/logger", () => mockLogger());
@@ -105,7 +102,7 @@ jest.mock("login.dfe.dao", () => {
                 reason: null,
                 numeric_identifier: "29",
                 text_identifier: "r6ffe4f",
-                createdAt: "2018-10-11T15:35:57.314Z",
+                createdAt: "2018-10-11T15:35:57.334Z",
                 updatedAt: "2019-04-25T08:32:32.008Z",
               },
               {
@@ -233,16 +230,16 @@ describe("when displaying the associate service view", () => {
         {
           id: "service1",
           isExternalService: true,
+          isHiddenForApprover: false,
           isMigrated: true,
           name: "Service One",
-          relyingParty: {},
         },
         {
           id: "service2",
           isExternalService: true,
+          isHiddenForApprover: false,
           isMigrated: true,
           name: "Service two",
-          relyingParty: {},
         },
       ],
     });
@@ -305,20 +302,10 @@ describe("when displaying the associate service view", () => {
     expect(res.redirect.mock.calls[0][0]).toBe("/approvals/users");
   });
 
-  it("should check if external service with no params", async () => {
-    getAllServices.mockReset();
-    getAllServices.mockReturnValue({
-      services: [
-        {
-          id: "service1",
-          dateActivated: "10/10/2018",
-          name: "service name",
-          status: "active",
-          isExternalService: true,
-          relyingParty: {},
-        },
-      ],
-    });
+  it("should render the associate services view with services from cache", async () => {
+    // beforeEach checkCacheForAllServices mock provides service1 and service2;
+    // service2 is already assigned to the user via getAllServicesForUserInOrg,
+    // so only service1 appears as available to select.
     await getAssociateServices(req, res);
     expect(res.render.mock.calls[0][1]).toMatchObject({
       csrfToken: "token",
@@ -341,22 +328,27 @@ describe("when displaying the associate service view", () => {
     });
   });
 
-  it("should display service if external service with params but no hideApprover", async () => {
-    getAllServices.mockReset();
-    getAllServices.mockReturnValue({
+  it("should display service if isHiddenForApprover is false", async () => {
+    checkCacheForAllServices.mockReturnValue({
       services: [
         {
           id: "service1",
-          dateActivated: "10/10/2018",
-          name: "service name",
-          status: "active",
           isExternalService: true,
-          relyingParty: {
-            params: {},
-          },
+          isHiddenForApprover: false,
+          isMigrated: true,
+          name: "Service One",
         },
       ],
     });
+    getAllServicesForUserInOrg.mockReturnValue([]);
+    policyEngine.getPolicyApplicationResultsForUser.mockReturnValue([
+      {
+        id: "service1",
+        policiesAppliedForUser: [],
+        rolesAvailableToUser: [],
+        serviceAvailableToUser: true,
+      },
+    ]);
     await getAssociateServices(req, res);
     expect(res.render.mock.calls[0][1]).toMatchObject({
       csrfToken: "token",
@@ -379,44 +371,39 @@ describe("when displaying the associate service view", () => {
     });
   });
 
-  it("should display service if external service with params but hideApprover false", async () => {
-    getAllServices.mockReset();
-    getAllServices.mockReturnValue({
-      services: [
-        {
-          id: "service1",
-          dateActivated: "10/10/2018",
-          name: "service name",
-          status: "active",
-          isExternalService: true,
-          relyingParty: {
-            params: {
-              hideApprover: false,
-            },
-          },
-        },
-      ],
-    });
-    await getAssociateServices(req, res);
-    expect(res.render.mock.calls[0][1]).toMatchObject({
-      csrfToken: "token",
-      name: "test name",
-      user: { email: "test@test.com", firstName: "test", lastName: "name" },
-      validationMessages: {},
-      backLink: "/approvals/users/user1",
-      currentPage: "users",
-      organisationDetails: undefined,
+  it("should exclude service if isHiddenForApprover is true", async () => {
+    checkCacheForAllServices.mockReturnValue({
       services: [
         {
           id: "service1",
           isExternalService: true,
+          isHiddenForApprover: true,
           isMigrated: true,
-          name: "Service One",
+          name: "Hidden Service",
+        },
+        {
+          id: "service2",
+          isExternalService: true,
+          isHiddenForApprover: false,
+          isMigrated: true,
+          name: "Visible Service",
         },
       ],
-      selectedServices: [],
-      isInvite: undefined,
     });
+    getAllServicesForUserInOrg.mockReturnValue([]);
+    policyEngine.getPolicyApplicationResultsForUser.mockImplementation(
+      (userId, organisationId, serviceIds) =>
+        serviceIds.map((id) => ({
+          id,
+          policiesAppliedForUser: [],
+          rolesAvailableToUser: [],
+          serviceAvailableToUser: true,
+        })),
+    );
+    await getAssociateServices(req, res);
+    const services = res.render.mock.calls[0][1].services;
+    expect(services.map((s) => s.id)).not.toContain("service1");
+    expect(services.map((s) => s.id)).toContain("service2");
   });
 
   it("then it should include the services", async () => {
@@ -443,23 +430,21 @@ describe("when displaying the associate service view", () => {
   });
 
   it("then it should exclude services that are not available based on policies", async () => {
-    getAllServices.mockReturnValue({
+    checkCacheForAllServices.mockReturnValue({
       services: [
         {
           id: "service1",
-          name: "service one",
+          name: "Service One",
           isExternalService: true,
-          relyingParty: {
-            params: {},
-          },
+          isHiddenForApprover: false,
+          isMigrated: true,
         },
         {
           id: "service2",
-          name: "service two",
+          name: "Service two",
           isExternalService: true,
-          relyingParty: {
-            params: {},
-          },
+          isHiddenForApprover: false,
+          isMigrated: true,
         },
       ],
     });

--- a/test/unit/app/users/getSelectServiceWithOrganisation.test.js
+++ b/test/unit/app/users/getSelectServiceWithOrganisation.test.js
@@ -4,6 +4,10 @@ jest.mock("./../../../../src/infrastructure/config", () =>
   require("../../../utils/jestMocks").mockConfig(),
 );
 
+jest.mock("../../../../src/infrastructure/helpers/allServicesAppCache", () => ({
+  checkCacheForAllServices: jest.fn().mockResolvedValue({ services: [] }),
+}));
+
 jest.mock("login.dfe.dao", () => {
   return {
     organisation: {

--- a/test/unit/app/users/getServices.test.js
+++ b/test/unit/app/users/getServices.test.js
@@ -97,6 +97,7 @@ describe("when displaying the users services", () => {
         {
           id: "service1",
           isExternalService: true,
+          isHiddenForApprover: false,
           isMigrated: true,
           isHiddenService: false,
           name: "Service One",
@@ -104,6 +105,7 @@ describe("when displaying the users services", () => {
         {
           id: "service2",
           isExternalService: true,
+          isHiddenForApprover: false,
           isMigrated: true,
           isHiddenService: false,
           name: "Service two",
@@ -156,6 +158,70 @@ describe("when displaying the users services", () => {
     expect(res.render.mock.calls[0][1]).toMatchObject({
       csrfToken: "token",
     });
+  });
+
+  it("should exclude a service with isHiddenForApprover: true from displayed services", async () => {
+    checkCacheForAllServices.mockReturnValue({
+      services: [
+        {
+          id: "service1",
+          isExternalService: true,
+          isHiddenForApprover: false,
+          isMigrated: true,
+          name: "Visible Service",
+        },
+        {
+          id: "service-hidden",
+          isExternalService: true,
+          isHiddenForApprover: true,
+          isMigrated: true,
+          name: "Hidden Service",
+        },
+      ],
+    });
+
+    await getServices(req, res);
+
+    const visibleUserOrgs = res.render.mock.calls[0][1].visibleUserOrgs;
+    const displayedIds = visibleUserOrgs.flatMap((org) =>
+      org.displayedServices.map((s) => s.id),
+    );
+    expect(displayedIds).not.toContain("service-hidden");
+  });
+
+  it("should include a service with isHiddenForApprover: false in displayed services", async () => {
+    mockGetOrganisationAndServiceForUser.mockReturnValue([
+      {
+        organisation: { id: "org1" },
+        services: [
+          {
+            id: "service1",
+            dateActivated: "10/10/2018",
+            name: "service name",
+            status: "active",
+          },
+        ],
+      },
+    ]);
+    checkCacheForAllServices.mockReturnValue({
+      services: [
+        {
+          id: "service1",
+          isExternalService: true,
+          isHiddenForApprover: false,
+          isMigrated: true,
+          name: "Visible Service",
+        },
+      ],
+    });
+
+    await getServices(req, res);
+
+    const visibleUserOrgs = res.render.mock.calls[0][1].visibleUserOrgs;
+    const displayedIds = visibleUserOrgs.flatMap((org) =>
+      org.displayedServices.map((s) => s.id),
+    );
+    expect(displayedIds).toContain("service1");
   });
 
   describe("when an invite journey is in progress during a user profile page visit", () => {

--- a/test/unit/app/users/postSelectServiceWithOrganisation.test.js
+++ b/test/unit/app/users/postSelectServiceWithOrganisation.test.js
@@ -8,6 +8,12 @@ jest.mock("./../../../../src/infrastructure/config", () =>
   require("../../../utils/jestMocks").mockConfig(),
 );
 
+jest.mock("../../../../src/infrastructure/helpers/allServicesAppCache", () => ({
+  checkCacheForAllServices: jest.fn().mockResolvedValue({
+    services: [{ id: "serviceId", isHiddenForApprover: false }],
+  }),
+}));
+
 jest.mock("../../../../src/app/users/utils", () => {
   return {
     isOrgEndUser: jest.fn(),

--- a/test/unit/app/users/selectServiceWithOrganisation.test.js
+++ b/test/unit/app/users/selectServiceWithOrganisation.test.js
@@ -1,0 +1,139 @@
+jest.mock("login.dfe.dao", () => ({
+  services: {
+    getFilteredUserServicesWithOrganisation: jest.fn(),
+  },
+  organisation: {
+    getStatusNameById: jest.fn().mockReturnValue("Open"),
+  },
+}));
+
+jest.mock("../../../../src/infrastructure/helpers/allServicesAppCache", () => ({
+  checkCacheForAllServices: jest.fn(),
+}));
+
+jest.mock("../../../../src/app/users/utils", () => ({
+  getOrgNaturalIdentifiers: jest.fn().mockReturnValue([]),
+  isRemoveService: jest.fn().mockReturnValue(false),
+  isOrgEndUser: jest.fn().mockReturnValue(false),
+}));
+
+const { services } = require("login.dfe.dao");
+const {
+  checkCacheForAllServices,
+} = require("../../../../src/infrastructure/helpers/allServicesAppCache");
+const {
+  get,
+} = require("../../../../src/app/users/selectServiceWithOrganisation");
+
+const makeServiceOrg = (serviceId, orgStatus = 1) => ({
+  id: `record-${serviceId}`,
+  Service: { id: serviceId, name: `Service ${serviceId}` },
+  Organisation: {
+    id: `org-${serviceId}`,
+    Status: orgStatus,
+    naturalIdentifiers: [],
+  },
+});
+
+describe("selectServiceWithOrganisation — isHiddenForApprover filtering", () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    req = {
+      user: { sub: "user1" },
+      session: {},
+      query: {},
+      csrfToken: () => "token",
+    };
+
+    res = {
+      render: jest.fn(),
+    };
+  });
+
+  it("includes services where isHiddenForApprover is false", async () => {
+    services.getFilteredUserServicesWithOrganisation.mockResolvedValue([
+      makeServiceOrg("svc-visible"),
+    ]);
+    checkCacheForAllServices.mockResolvedValue({
+      services: [{ id: "svc-visible", isHiddenForApprover: false }],
+    });
+
+    await get(req, res);
+
+    const rendered = res.render.mock.calls[0][1];
+    expect(rendered.serviceOrganisations).toHaveLength(1);
+    expect(rendered.serviceOrganisations[0].Service.id).toBe("svc-visible");
+  });
+
+  it("excludes services where isHiddenForApprover is true", async () => {
+    services.getFilteredUserServicesWithOrganisation.mockResolvedValue([
+      makeServiceOrg("svc-hidden"),
+      makeServiceOrg("svc-visible"),
+    ]);
+    checkCacheForAllServices.mockResolvedValue({
+      services: [
+        { id: "svc-hidden", isHiddenForApprover: true },
+        { id: "svc-visible", isHiddenForApprover: false },
+      ],
+    });
+
+    await get(req, res);
+
+    const rendered = res.render.mock.calls[0][1];
+    expect(rendered.serviceOrganisations).toHaveLength(1);
+    expect(rendered.serviceOrganisations[0].Service.id).toBe("svc-visible");
+    expect(
+      rendered.serviceOrganisations.find(
+        (so) => so.Service.id === "svc-hidden",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("excludes services not present in the cache (isHiddenForApprover undefined → not in cache set)", async () => {
+    services.getFilteredUserServicesWithOrganisation.mockResolvedValue([
+      makeServiceOrg("svc-visible"),
+    ]);
+    // Cache returns empty — no hidden IDs
+    checkCacheForAllServices.mockResolvedValue({ services: [] });
+
+    await get(req, res);
+
+    const rendered = res.render.mock.calls[0][1];
+    expect(rendered.serviceOrganisations).toHaveLength(1);
+  });
+
+  it("handles checkCacheForAllServices returning null/undefined safely", async () => {
+    services.getFilteredUserServicesWithOrganisation.mockResolvedValue([
+      makeServiceOrg("svc-visible"),
+    ]);
+    checkCacheForAllServices.mockResolvedValue(null);
+
+    await get(req, res);
+
+    const rendered = res.render.mock.calls[0][1];
+    expect(rendered.serviceOrganisations).toHaveLength(1);
+  });
+
+  it("still filters out hidden-organisation services regardless of isHiddenForApprover", async () => {
+    services.getFilteredUserServicesWithOrganisation.mockResolvedValue([
+      makeServiceOrg("svc-active", 1),
+      makeServiceOrg("svc-hidden-org", 0),
+    ]);
+    checkCacheForAllServices.mockResolvedValue({
+      services: [
+        { id: "svc-active", isHiddenForApprover: false },
+        { id: "svc-hidden-org", isHiddenForApprover: false },
+      ],
+    });
+
+    await get(req, res);
+
+    const rendered = res.render.mock.calls[0][1];
+    expect(rendered.serviceOrganisations).toHaveLength(1);
+    expect(rendered.serviceOrganisations[0].Service.id).toBe("svc-active");
+  });
+});

--- a/test/unit/app/users/selectServiceWithOrganisation.test.js
+++ b/test/unit/app/users/selectServiceWithOrganisation.test.js
@@ -93,7 +93,7 @@ describe("selectServiceWithOrganisation — isHiddenForApprover filtering", () =
     ).toBeUndefined();
   });
 
-  it("excludes services not present in the cache (isHiddenForApprover undefined → not in cache set)", async () => {
+  it("includes services when cache returns empty (empty hidden set means nothing is hidden)", async () => {
     services.getFilteredUserServicesWithOrganisation.mockResolvedValue([
       makeServiceOrg("svc-visible"),
     ]);


### PR DESCRIPTION
## NSA-9688 — Toggle whether or not service is hidden via manage

Filters services with `isHiddenForApprover: true` out of the approver-facing service lists. The `isHiddenForApprover` flag is a computed field returned by the applications API — it is set by the manage console hide service toggle.

### What changed

- Service listing and search queries use `getPaginatedServicesRaw` (which preserves computed fields) rather than the transformed variant, so `isHiddenForApprover` is available for filtering.
- Services where `isHiddenForApprover === true` are excluded from results shown to approver users.

### Testing

Unit tests cover:
- Services with `isHiddenForApprover: true` are excluded from the rendered list
- Services with `isHiddenForApprover: false` are included as normal
