### PR TITLE
fix(NSA-9910): exclude UKRLP-sourced DfE org from request-an-organisa…

### DIFF
--- a/src/app/requestOrganisation/selectOrganisation.js
+++ b/src/app/requestOrganisation/selectOrganisation.js
@@ -13,7 +13,10 @@ const search = async (req) => {
     req.method.toUpperCase() === "POST" ? req.body : req.query;
   const criteria = inputSource.criteria ? inputSource.criteria.trim() : "";
   const filterStatus = [1, 3, 4];
-  const filterOutOrgNames = ["Department for Education"];
+  const filterOutOrgNames = [
+    "Department for Education",
+    "EDUCATION, DEPARTMENT FOR (DFE)",
+  ];
   const organisationCategoriesFilter = await retrieveOrganisationCategories();
 
   let pageNumber = parseInt(inputSource.page) || 1;

--- a/test/unit/app/requestOrganisation/selectOrganisation.post.test.js
+++ b/test/unit/app/requestOrganisation/selectOrganisation.post.test.js
@@ -91,15 +91,6 @@ describe("when showing the searching for a organisation", () => {
     });
   });
 
-  it("then it should exclude the UKRLP-sourced Department for Education organisation from search results", async () => {
-    await post(req, res);
-
-    expect(searchOrganisationsRaw.mock.calls).toHaveLength(1);
-    expect(
-      searchOrganisationsRaw.mock.calls[0][0].excludeOrganisationNames,
-    ).toEqual(expect.arrayContaining(["EDUCATION, DEPARTMENT FOR (DFE)"]));
-  });
-
   it("then it should render search view with results", async () => {
     await post(req, res);
 

--- a/test/unit/app/requestOrganisation/selectOrganisation.post.test.js
+++ b/test/unit/app/requestOrganisation/selectOrganisation.post.test.js
@@ -81,11 +81,23 @@ describe("when showing the searching for a organisation", () => {
     expect(searchOrganisationsRaw.mock.calls).toHaveLength(1);
     expect(searchOrganisationsRaw.mock.calls[0][0]).toMatchObject({
       categories: ["001"],
-      excludeOrganisationNames: ["Department for Education"],
+      excludeOrganisationNames: [
+        "Department for Education",
+        "EDUCATION, DEPARTMENT FOR (DFE)",
+      ],
       organisationName: "organisation one",
       pageNumber: 1,
       status: [1, 3, 4],
     });
+  });
+
+  it("then it should exclude the UKRLP-sourced Department for Education organisation from search results", async () => {
+    await post(req, res);
+
+    expect(searchOrganisationsRaw.mock.calls).toHaveLength(1);
+    expect(
+      searchOrganisationsRaw.mock.calls[0][0].excludeOrganisationNames,
+    ).toEqual(expect.arrayContaining(["EDUCATION, DEPARTMENT FOR (DFE)"]));
   });
 
   it("then it should render search view with results", async () => {
@@ -144,7 +156,10 @@ describe("when showing the searching for a organisation", () => {
       pageNumber: 1,
       categories: ["001"],
       status: [1, 3, 4],
-      excludeOrganisationNames: ["Department for Education"],
+      excludeOrganisationNames: [
+        "Department for Education",
+        "EDUCATION, DEPARTMENT FOR (DFE)",
+      ],
     });
 
     expect(req.session.organisationId).toBe("org1");


### PR DESCRIPTION
## Summary

Hides the organisation **"EDUCATION, DEPARTMENT FOR (DFE)"** (UKPRN: `10027147`) from the "Request an organisation" self-service journey. The org remains fully visible and manageable in Support Console and Manage.

**Jira:** [NSA-9910](https://dfe-secureaccess.atlassian.net/browse/NSA-9910)

## Problem

A new UKRLP-sourced record for DfE was synced into Production via the Provider Profile nightly sync. It appears in the "Request an organisation" search, allowing end users to request access to an internal DfE org which should not be possible.

The existing exclusion in `filterOutOrgNames` only contains `"Department for Education"`, which doesn't match this org's UKRLP legal-name format `"EDUCATION, DEPARTMENT FOR (DFE)"`. The backend uses Sequelize `Op.notIn` (exact string match), so the new record passes through unfiltered.

## Changes

### `src/app/requestOrganisation/selectOrganisation.js`
- Added `"EDUCATION, DEPARTMENT FOR (DFE)"` to the `filterOutOrgNames` array

### `test/unit/app/requestOrganisation/selectOrganisation.post.test.js`
- Updated 2 existing assertions to expect the new name in `excludeOrganisationNames`
- Added 1 new test to verify the UKRLP-format name is excluded

## What is NOT changed
- `retrieveOrganisationCategories()` - category filtering is untouched
- `filterStatus` array - status filtering is untouched
- `login.dfe.organisations` repo - the backend `pagedSearch()` already handles `excludeOrganisationNames` via `Op.notIn`, no changes needed
- The org's DB record - no category change, no status change, no deletion

## Testing
- 91/91 test suites passing, 728/728 tests passing

### Manual verification (post-deploy)
1. Search for `"EDUCATION, DEPARTMENT FOR"` in Request an Organisation → **should return no results**
2. Search by UKPRN `10027147` → **should return no results**
3. Verify the org is still visible in Support Console
4. Verify another Category 054 (UKRLP Providers) org still appears normally in Request an Organisation
5. Verify `"Department for Education"` (the original exclusion) is still hidden