### PR TITLE
NSA-9940: Fix UKRLP 054 filter using client_id after raw cache switch

### DIFF
--- a/src/app/requestService/requestService.js
+++ b/src/app/requestService/requestService.js
@@ -76,7 +76,7 @@ const getAllAvailableServices = async (req) => {
     by: { organisationId: req.params.orgId },
   });
   if (orgDetails?.category?.id === "054") {
-    return available.filter((svc) => svc.relyingParty?.clientId === "ukRlp");
+    return available.filter((svc) => svc.relyingParty?.client_id === "ukRlp");
   }
   return available;
 };

--- a/src/app/requestService/requestService.js
+++ b/src/app/requestService/requestService.js
@@ -76,7 +76,9 @@ const getAllAvailableServices = async (req) => {
     by: { organisationId: req.params.orgId },
   });
   if (orgDetails?.category?.id === "054") {
-    return available.filter((svc) => svc.relyingParty?.client_id === "ukRlp");
+    return externalServices.filter(
+      (svc) => svc.relyingParty?.client_id === "ukRlp",
+    );
   }
   return available;
 };

--- a/src/app/users/associateServices.js
+++ b/src/app/users/associateServices.js
@@ -141,7 +141,9 @@ const getAllAvailableServices = async (req) => {
     by: { organisationId: req.params.orgId },
   });
   if (orgDetails?.category?.id === "054") {
-    return available.filter((svc) => svc.relyingParty?.client_id === "ukRlp");
+    return externalServices.filter(
+      (svc) => svc.relyingParty?.client_id === "ukRlp",
+    );
   }
   return available;
 };

--- a/src/app/users/associateServices.js
+++ b/src/app/users/associateServices.js
@@ -141,7 +141,7 @@ const getAllAvailableServices = async (req) => {
     by: { organisationId: req.params.orgId },
   });
   if (orgDetails?.category?.id === "054") {
-    return available.filter((svc) => svc.relyingParty?.clientId === "ukRlp");
+    return available.filter((svc) => svc.relyingParty?.client_id === "ukRlp");
   }
   return available;
 };


### PR DESCRIPTION
## Summary

- NSA-9688 switched the app service cache from \`getPaginatedServices\` (transformed, camelCase) to \`getPaginatedServicesRaw\` (raw, snake_case)
- The NSA-9733 category 054 filter still referenced \`relyingParty.clientId\` (camelCase), which is always \`undefined\` on raw data
- Category 054 orgs (UKRLP-only) were seeing zero services instead of UKRLP only
- Fix: changed \`clientId\` → \`client_id\` in both \`associateServices.js\` and \`requestService.js\`

## Test plan

- [ ] Deploy to pre-prod and verify a category 054 org user sees only the UKRLP service in both the request-service and approvals associate-services flows
- [ ] Verify a non-054 org user is unaffected and sees their normal services
- [ ] All 738 unit tests pass

Relates to: NSA-9940